### PR TITLE
simplify model loading from local ckpt

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -34,6 +34,13 @@ We also provide a model factory that can build a task specific model for a downs
 
 By passing a list of bands being used to the constructor, we automatically filter out unused bands, and randomly initialize weights for new bands that were not pretrained on.
 
+!!! info
+
+    To pass your own path from where to load the weights with the PrithviModelFactory, you can make use of timm's `pretrained_cfg_overlay`.
+    E.g. to pass a local path, you can pass the parameter `backbone_pretrained_cfg_overlay = {"file": "<local_path>"}` to the model factory.
+    
+    Besides `file`, you can also pass `url`, `hf_hub_id`, amongst others. Check timm's documentation for full details.
+
 :::terratorch.models.backbones.prithvi_select_patch_embed_weights
 
 ## Decoders

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -105,6 +105,17 @@ task = PixelwiseRegressionTask(
 
 At this level of abstraction, you can also provide a configuration file (see [LightningCLI](https://lightning.ai/docs/pytorch/stable/cli/lightning_cli.html#lightning-cli)) with all the details of the training. See an example for semantic segmentation below:
 
+!!! info
+
+    To pass your own path from where to load the weights with the PrithviModelFactory, you can make use of timm's `pretrained_cfg_overlay`.
+    E.g. to pass a local path, you can add, under model_args:
+    
+    ```yaml
+    backbone_pretrained_cfg_overlay:
+        file: <local_path>
+    ```
+    Besides `file`, you can also pass `url`, `hf_hub_id`, amongst others. Check timm's documentation for full details.
+
 ```yaml title="Configuration file for a Semantic Segmentation Task"
 # lightning.pytorch==2.1.1
 seed_everything: 0

--- a/examples/confs/sen1floods11_vit_local_ckpt.yaml
+++ b/examples/confs/sen1floods11_vit_local_ckpt.yaml
@@ -87,8 +87,8 @@ model:
       backbone_patch_size: 16
       backbone_in_chans: 6
       backbone_num_frames: 1
-      backbone_checkpoint_path: examples/Prithvi_100M.pt
-      # backbone_window_size: 8
+      backbone_pretrained_cfg_overlay:
+        file: examples/Prithvi_100M.pt
       decoder_channels: 256
       in_channels: 6
       bands:


### PR DESCRIPTION
Leverage timm's capabilities to simplify loading from a user file.
This adds some more complexity to the config file but is transparent with regards to what exactly gets passed to timm.