### PR TITLE
simplify config files for vit sen1floods11

### DIFF
--- a/examples/confs/sen1floods11_vit.yaml
+++ b/examples/confs/sen1floods11_vit.yaml
@@ -79,7 +79,6 @@ model:
       decoder: FCNDecoder
       pretrained: true
       backbone: prithvi_vit_100
-      backbone_pretrain_img_size: 512
       decoder_channels: 256
       in_channels: 6
       bands:

--- a/examples/confs/sen1floods11_vit_local_ckpt.yaml
+++ b/examples/confs/sen1floods11_vit_local_ckpt.yaml
@@ -77,14 +77,6 @@ model:
       decoder: FCNDecoder
       pretrained: true
       backbone: prithvi_vit_100
-      backbone_embed_dim: 768
-      backbone_num_heads: 12 
-      backbone_decoder_depth: 8
-      backbone_decoder_num_heads: 16
-      backbone_decoder_embed_dim: 512
-      backbone_mlp_ratio: 4
-      backbone_patch_size: 16
-      backbone_in_chans: 6
       backbone_pretrained_cfg_overlay:
         file: examples/Prithvi_100M.pt
       decoder_channels: 256

--- a/examples/confs/sen1floods11_vit_local_ckpt.yaml
+++ b/examples/confs/sen1floods11_vit_local_ckpt.yaml
@@ -77,7 +77,6 @@ model:
       decoder: FCNDecoder
       pretrained: true
       backbone: prithvi_vit_100
-      backbone_pretrain_img_size: 512
       backbone_embed_dim: 768
       backbone_num_heads: 12 
       backbone_decoder_depth: 8
@@ -86,7 +85,6 @@ model:
       backbone_mlp_ratio: 4
       backbone_patch_size: 16
       backbone_in_chans: 6
-      backbone_num_frames: 1
       backbone_pretrained_cfg_overlay:
         file: examples/Prithvi_100M.pt
       decoder_channels: 256


### PR DESCRIPTION
`backbone_pretrain_img_size` is only relevant if we are instantiating the full model with timm. For finetuning it is ignored, so we should not have it in the configs.

Additionally, `backbone_num_frames` is provided through the model factory, so it should not be passed through the config as a `model_args.backbone_num_frames`, only `num_frames`.