### PR TITLE
add scale modules to upernet for vit backbone

### DIFF
--- a/tests/test_prithvi_model_factory.py
+++ b/tests/test_prithvi_model_factory.py
@@ -8,7 +8,7 @@ import torch
 from terratorch.models import PrithviModelFactory
 from terratorch.models.backbones.prithvi_vit import PRETRAINED_BANDS
 
-#from terratorch.models.backbones.prithvi_vit import default_cfgs as vit_default_cfgs
+# from terratorch.models.backbones.prithvi_vit import default_cfgs as vit_default_cfgs
 from terratorch.models.model import AuxiliaryHead
 
 NUM_CHANNELS = 6
@@ -16,6 +16,11 @@ NUM_CLASSES = 2
 EXPECTED_SEGMENTATION_OUTPUT_SHAPE = (1, NUM_CLASSES, 224, 224)
 EXPECTED_REGRESSION_OUTPUT_SHAPE = (1, 224, 224)
 EXPECTED_CLASSIFICATION_OUTPUT_SHAPE = (1, NUM_CLASSES)
+
+PIXELWISE_TASK_EXPECTED_OUTPUT = [
+    ("regression", EXPECTED_REGRESSION_OUTPUT_SHAPE),
+    ("segmentation", EXPECTED_SEGMENTATION_OUTPUT_SHAPE),
+]
 
 
 @pytest.fixture(scope="session")
@@ -26,6 +31,7 @@ def model_factory() -> PrithviModelFactory:
 @pytest.fixture(scope="session")
 def model_input() -> torch.Tensor:
     return torch.ones((1, NUM_CHANNELS, 224, 224))
+
 
 @pytest.mark.parametrize("backbone", ["prithvi_vit_100", "prithvi_vit_300"])
 def test_create_classification_model(backbone, model_factory: PrithviModelFactory, model_input):
@@ -43,6 +49,7 @@ def test_create_classification_model(backbone, model_factory: PrithviModelFactor
     with torch.no_grad():
         assert model(model_input).output.shape == EXPECTED_CLASSIFICATION_OUTPUT_SHAPE
 
+
 @pytest.mark.parametrize("backbone", ["prithvi_vit_100", "prithvi_vit_300"])
 def test_create_classification_model_no_in_channels(backbone, model_factory: PrithviModelFactory, model_input):
     model = model_factory.build_model(
@@ -58,133 +65,115 @@ def test_create_classification_model_no_in_channels(backbone, model_factory: Pri
     with torch.no_grad():
         assert model(model_input).output.shape == EXPECTED_CLASSIFICATION_OUTPUT_SHAPE
 
+
 @pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
+@pytest.mark.parametrize("task,expected", PIXELWISE_TASK_EXPECTED_OUTPUT)
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_segmentation_model(backbone, decoder, model_factory: PrithviModelFactory, model_input):
-    model = model_factory.build_model(
-        "segmentation",
-        backbone=backbone,
-        decoder=decoder,
-        in_channels=NUM_CHANNELS,
-        bands=PRETRAINED_BANDS,
-        pretrained=False,
-        num_classes=NUM_CLASSES,
-    )
+def test_create_pixelwise_model(backbone, task, expected, decoder, model_factory: PrithviModelFactory, model_input):
+    model_args = {
+        "task": task,
+        "backbone": backbone,
+        "decoder": decoder,
+        "in_channels": NUM_CHANNELS,
+        "bands": PRETRAINED_BANDS,
+        "pretrained": False,
+    }
+
+    if task == "segmentation":
+        model_args["num_classes"] = NUM_CLASSES
+    if decoder == "UperNetDecoder":
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
+
+    model = model_factory.build_model(**model_args)
     model.eval()
 
     with torch.no_grad():
-        assert model(model_input).output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+        assert model(model_input).output.shape == expected
+
 
 @pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
+@pytest.mark.parametrize("task,expected", PIXELWISE_TASK_EXPECTED_OUTPUT)
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_segmentation_model_no_in_channels(backbone, decoder, model_factory: PrithviModelFactory, model_input):
-    model = model_factory.build_model(
-        "segmentation",
-        backbone=backbone,
-        decoder=decoder,
-        bands=PRETRAINED_BANDS,
-        pretrained=False,
-        num_classes=NUM_CLASSES,
-    )
+def test_create_pixelwise_model_no_in_channels(
+    backbone, task, expected, decoder, model_factory: PrithviModelFactory, model_input
+):
+    model_args = {
+        "task": task,
+        "backbone": backbone,
+        "decoder": decoder,
+        "bands": PRETRAINED_BANDS,
+        "pretrained": False,
+    }
+
+    if task == "segmentation":
+        model_args["num_classes"] = NUM_CLASSES
+    if decoder == "UperNetDecoder":
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
+
+    model = model_factory.build_model(**model_args)
     model.eval()
 
     with torch.no_grad():
-        assert model(model_input).output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+        assert model(model_input).output.shape == expected
 
 
 @pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
+@pytest.mark.parametrize("task,expected", PIXELWISE_TASK_EXPECTED_OUTPUT)
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_segmentation_model_with_aux_heads(backbone, decoder, model_factory: PrithviModelFactory, model_input):
+def test_create_pixelwise_model_with_aux_heads(
+    backbone, task, expected, decoder, model_factory: PrithviModelFactory, model_input
+):
     aux_heads_name = ["first_aux", "second_aux"]
-    model = model_factory.build_model(
-        "segmentation",
-        backbone=backbone,
-        decoder=decoder,
-        in_channels=NUM_CHANNELS,
-        bands=PRETRAINED_BANDS,
-        pretrained=False,
-        num_classes=NUM_CLASSES,
-        aux_decoders=[AuxiliaryHead(name, "FCNDecoder", None) for name in aux_heads_name],
-    )
+    model_args = {
+        "task": task,
+        "backbone": backbone,
+        "decoder": decoder,
+        "in_channels": NUM_CHANNELS,
+        "bands": PRETRAINED_BANDS,
+        "pretrained": False,
+        "aux_decoders": [AuxiliaryHead(name, "FCNDecoder", None) for name in aux_heads_name],
+    }
+    if task == "segmentation":
+        model_args["num_classes"] = NUM_CLASSES
+
+    if decoder == "UperNetDecoder":
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
+
+    model = model_factory.build_model(**model_args)
     model.eval()
 
     with torch.no_grad():
         model_output = model(model_input)
-        assert model_output.output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+        assert model_output.output.shape == expected
 
         assert len(model_output.auxiliary_heads.keys() & aux_heads_name) == len(aux_heads_name)
         for _, output in model_output.auxiliary_heads.items():
-            assert output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+            assert output.shape == expected
 
 
 @pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
+@pytest.mark.parametrize("task,expected", PIXELWISE_TASK_EXPECTED_OUTPUT)
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_regression_model(backbone, decoder, model_factory: PrithviModelFactory, model_input):
-    model = model_factory.build_model(
-        "regression",
-        backbone=backbone,
-        decoder=decoder,
-        in_channels=NUM_CHANNELS,
-        bands=PRETRAINED_BANDS,
-        pretrained=False,
-    )
-    model.eval()
+def test_create_pixelwise_model_with_extra_bands(backbone, task, expected, decoder, model_factory: PrithviModelFactory):
+    model_args = {
+        "task": task,
+        "backbone": backbone,
+        "decoder": decoder,
+        "in_channels": NUM_CHANNELS + 1,
+        "bands": [*PRETRAINED_BANDS, 7],
+        "pretrained": False,
+    }
+    if task == "segmentation":
+        model_args["num_classes"] = NUM_CLASSES
 
-    with torch.no_grad():
-        assert model(model_input).output.shape == EXPECTED_REGRESSION_OUTPUT_SHAPE
-
-@pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
-@pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_regression_model_no_in_channels(backbone, decoder, model_factory: PrithviModelFactory, model_input):
-    model = model_factory.build_model(
-        "regression",
-        backbone=backbone,
-        decoder=decoder,
-        bands=PRETRAINED_BANDS,
-        pretrained=False,
-    )
-    model.eval()
-
-    with torch.no_grad():
-        assert model(model_input).output.shape == EXPECTED_REGRESSION_OUTPUT_SHAPE
-
-@pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
-@pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_regression_model_with_aux_heads(backbone, decoder, model_factory: PrithviModelFactory, model_input):
-    aux_heads_name = ["first_aux", "second_aux"]
-    model = model_factory.build_model(
-        "regression",
-        backbone=backbone,
-        decoder=decoder,
-        in_channels=NUM_CHANNELS,
-        bands=PRETRAINED_BANDS,
-        pretrained=False,
-        aux_decoders=[AuxiliaryHead(name, "FCNDecoder", None) for name in aux_heads_name],
-    )
-    model.eval()
-
-    with torch.no_grad():
-        model_output = model(model_input)
-        assert model_output.output.shape == EXPECTED_REGRESSION_OUTPUT_SHAPE
-
-        assert len(model_output.auxiliary_heads.keys() & aux_heads_name) == len(aux_heads_name)
-        for _, output in model_output.auxiliary_heads.items():
-            assert output.shape == EXPECTED_REGRESSION_OUTPUT_SHAPE
-
-
-@pytest.mark.parametrize("backbone", ["prithvi_vit_100"])
-@pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
-def test_create_model_with_extra_bands(backbone, decoder, model_factory: PrithviModelFactory):
-    model = model_factory.build_model(
-        "segmentation",
-        backbone=backbone,
-        decoder=decoder,
-        in_channels=NUM_CHANNELS + 1,
-        bands=[*PRETRAINED_BANDS, 7],  # add an extra band
-        pretrained=False,
-        num_classes=NUM_CLASSES,
-    )
+    if decoder == "UperNetDecoder":
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
+    model = model_factory.build_model(**model_args)
     model.eval()
     model_input = torch.ones((1, NUM_CHANNELS + 1, 224, 224))
     with torch.no_grad():
-        assert model(model_input).output.shape == EXPECTED_SEGMENTATION_OUTPUT_SHAPE
+        assert model(model_input).output.shape == expected

--- a/tests/test_prithvi_tasks.py
+++ b/tests/test_prithvi_tasks.py
@@ -22,21 +22,26 @@ def model_input() -> torch.Tensor:
     return torch.ones((1, NUM_CHANNELS, 224, 224))
 
 
-@pytest.mark.parametrize("backbone",["prithvi_vit_100", "prithvi_vit_300", "prithvi_swin_B"])
+@pytest.mark.parametrize("backbone", ["prithvi_vit_100", "prithvi_vit_300", "prithvi_swin_B"])
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
 @pytest.mark.parametrize("loss", ["ce", "jaccard", "focal", "dice"])
 def test_create_segmentation_task(backbone, decoder, loss, model_factory: PrithviModelFactory):
+    model_args = {
+        "backbone": backbone,
+        "decoder": decoder,
+        "in_channels": NUM_CHANNELS,
+        "bands": PRETRAINED_BANDS,
+        "pretrained": False,
+        "num_classes": NUM_CLASSES,
+    }
+
+    if decoder == "UperNetDecoder" and backbone.startswith("prithvi_vit"):
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
     SemanticSegmentationTask(
-        {
-            "backbone": backbone,
-            "decoder": decoder,
-            "in_channels": NUM_CHANNELS,
-            "bands": PRETRAINED_BANDS,
-            "pretrained": False,
-            "num_classes": NUM_CLASSES,
-        },
+        model_args,
         model_factory,
-        loss=loss
+        loss=loss,
     )
 
 
@@ -44,16 +49,22 @@ def test_create_segmentation_task(backbone, decoder, loss, model_factory: Prithv
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
 @pytest.mark.parametrize("loss", ["mae", "rmse", "huber"])
 def test_create_regression_task(backbone, decoder, loss, model_factory: PrithviModelFactory):
+    model_args = {
+        "backbone": backbone,
+        "decoder": decoder,
+        "in_channels": NUM_CHANNELS,
+        "bands": PRETRAINED_BANDS,
+        "pretrained": False,
+    }
+
+    if decoder == "UperNetDecoder" and backbone.startswith("prithvi_vit"):
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
+
     PixelwiseRegressionTask(
-        {
-            "backbone": backbone,
-            "decoder": decoder,
-            "in_channels": NUM_CHANNELS,
-            "bands": PRETRAINED_BANDS,
-            "pretrained": False,
-        },
+        model_args,
         model_factory,
-        loss=loss
+        loss=loss,
     )
 
 
@@ -61,15 +72,21 @@ def test_create_regression_task(backbone, decoder, loss, model_factory: PrithviM
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder"])
 @pytest.mark.parametrize("loss", ["ce", "bce", "jaccard", "focal"])
 def test_create_classification_task(backbone, decoder, loss, model_factory: PrithviModelFactory):
+    model_args = {
+        "backbone": backbone,
+        "decoder": decoder,
+        "in_channels": NUM_CHANNELS,
+        "bands": PRETRAINED_BANDS,
+        "pretrained": False,
+        "num_classes": NUM_CLASSES,
+    }
+
+    if decoder == "UperNetDecoder" and backbone.startswith("prithvi_vit"):
+        model_args["out_indices"] = [1, 2, 3, 4]
+        model_args["scale_modules"] = True
+
     ClassificationTask(
-        {
-            "backbone": backbone,
-            "decoder": decoder,
-            "in_channels": NUM_CHANNELS,
-            "bands": PRETRAINED_BANDS,
-            "pretrained": False,
-            "num_classes": NUM_CLASSES,
-        },
+        model_args,
         model_factory,
-        loss=loss
+        loss=loss,
     )


### PR DESCRIPTION
The upernet decoder has been shown to perform better with vit.
In order to enable this, "scale modules" must be added to adapt the vit to produce "hierarchical" feature maps that upernet expects.

Also simplified some tests by leveraging `parametrize`