### PR TITLE
Extend/bands

### DIFF
--- a/terratorch/models/backbones/prithvi_swin.py
+++ b/terratorch/models/backbones/prithvi_swin.py
@@ -18,6 +18,7 @@ from timm.models.swin_transformer import checkpoint_filter_fn as timm_swin_check
 from terratorch.datasets.utils import HLSBands
 from terratorch.models.backbones.prithvi_select_patch_embed_weights import prithvi_select_patch_embed_weights
 from terratorch.models.backbones.swin_encoder_decoder import MMSegSwinTransformer
+from terratorch.models.backbones.utils import _estimate_in_chans
 
 PRETRAINED_BANDS = [
     HLSBands.BLUE,
@@ -174,7 +175,8 @@ def _create_swin_mmseg_transformer(
     # the current swin model is not multitemporal
     if "num_frames" in kwargs:
         kwargs = {k: v for k, v in kwargs.items() if k != "num_frames"}
-    kwargs["in_chans"] = len(model_bands)
+
+    kwargs["in_chans"] = _estimate_in_chans(model_bands=model_bands)
 
     def checkpoint_filter_wrapper_fn(state_dict, model):
         return checkpoint_filter_fn(state_dict, model, pretrained_bands, model_bands)

--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -14,6 +14,7 @@ from torch import nn
 from terratorch.datasets import HLSBands
 from terratorch.models.backbones.prithvi_select_patch_embed_weights import prithvi_select_patch_embed_weights
 from terratorch.models.backbones.vit_encoder_decoder import TemporalViTEncoder
+from terratorch.models.backbones.utils import _estimate_in_chans
 
 PRETRAINED_BANDS = [
     HLSBands.BLUE,
@@ -81,7 +82,7 @@ def _create_prithvi(
     if "features_only" in kwargs:
         kwargs = {k: v for k, v in kwargs.items() if k != "features_only"}
 
-    kwargs["in_chans"] = len(model_bands)
+    kwargs["in_chans"] = _estimate_in_chans(model_bands=model_bands)
 
     def checkpoint_filter_wrapper_fn(state_dict, model):
         return checkpoint_filter_fn(state_dict, model, pretrained_bands, model_bands)

--- a/terratorch/models/backbones/utils.py
+++ b/terratorch/models/backbones/utils.py
@@ -19,12 +19,14 @@ def _estimate_in_chans(model_bands: list[HLSBands] | list[str] | tuple[int, int]
     is_sublist, requires_special_eval = _are_sublists_of_int(model_bands)
 
     # Bands as intervals limited by integers
+    # The bands numbering follows the Python convention (starts with 0)
+    # and includes the extrema (so the +1 in order to include the last band)
     if requires_special_eval:
 
         if is_sublist:
-            in_chans = sum([i[-1] - i[0] for i in model_bands])
+            in_chans = sum([i[-1] - i[0] + 1 for i in model_bands])
         else:
-            in_chans = model_bands[-1] - model_bands[0]
+            in_chans = model_bands[-1] - model_bands[0] + 1
     else:
         in_chans = len(model_bands) 
 

--- a/terratorch/models/backbones/utils.py
+++ b/terratorch/models/backbones/utils.py
@@ -1,0 +1,31 @@
+from terratorch.datasets import HLSBands
+
+def _are_sublists_of_int(item) -> bool:
+
+    if all([isinstance(i, list) for i in item]):
+        if all([isinstance(i, int) for i in sum(item, [])]):
+            return True
+        else:
+            return False
+    else:
+        return False
+
+def _estimate_in_chans(model_bands: list[HLSBands] | list[str] | tuple[int, int] = None) -> int:
+
+    # Conditional to deal with the different possible choices for the bands 
+    # Bands as lists of strings or enum
+    if all([isinstance(b, str) for b in model_bands]): 
+        in_chans = len(model_bands)
+    # Bands as intervals limited by integers
+    elif all([isinstance(b, int) for b in model_bands] or _are_sublists_of_int(model_bands)):
+
+        if _are_sublists_of_int(model_bands):
+            in_chans = sum([i[-1] - i[0] for i in model_bands])
+        else:
+            in_chans = model_bands[-1] - model_bands[0]
+    else:
+        raise Exception(f"Expected bands to be list(str) or [int, int] but received {model_bands}")
+    
+    return in_chans
+
+

--- a/terratorch/models/backbones/utils.py
+++ b/terratorch/models/backbones/utils.py
@@ -14,7 +14,7 @@ def _estimate_in_chans(model_bands: list[HLSBands] | list[str] | tuple[int, int]
 
     # Conditional to deal with the different possible choices for the bands 
     # Bands as lists of strings or enum
-    if all([isinstance(b, str) for b in model_bands]): 
+    if all([isinstance(b, str) or isinstance(b, HLSBands) for b in model_bands]): 
         in_chans = len(model_bands)
     # Bands as intervals limited by integers
     elif all([isinstance(b, int) for b in model_bands] or _are_sublists_of_int(model_bands)):

--- a/terratorch/models/backbones/utils.py
+++ b/terratorch/models/backbones/utils.py
@@ -1,31 +1,33 @@
 from terratorch.datasets import HLSBands
 
-def _are_sublists_of_int(item) -> bool:
+def _are_sublists_of_int(item) -> (bool, bool):
 
     if all([isinstance(i, list) for i in item]):
         if all([isinstance(i, int) for i in sum(item, [])]):
-            return True
+            return True, True
         else:
-            return False
+            raise Exception(f"It's expected sublists be [int, int], but rceived {model_bands}")
+    elif len(item) == 2 and type(item[0]) == type(item[1]) == int:
+        return False, True
     else:
-        return False
+        return False, False
 
 def _estimate_in_chans(model_bands: list[HLSBands] | list[str] | tuple[int, int] = None) -> int:
 
     # Conditional to deal with the different possible choices for the bands 
     # Bands as lists of strings or enum
-    if all([isinstance(b, str) or isinstance(b, HLSBands) for b in model_bands]): 
-        in_chans = len(model_bands)
-    # Bands as intervals limited by integers
-    elif all([isinstance(b, int) for b in model_bands] or _are_sublists_of_int(model_bands)):
+    is_sublist, requires_special_eval = _are_sublists_of_int(model_bands)
 
-        if _are_sublists_of_int(model_bands):
+    # Bands as intervals limited by integers
+    if requires_special_eval:
+
+        if is_sublist:
             in_chans = sum([i[-1] - i[0] for i in model_bands])
         else:
             in_chans = model_bands[-1] - model_bands[0]
     else:
-        raise Exception(f"Expected bands to be list(str) or [int, int] but received {model_bands}")
-    
+        in_chans = len(model_bands) 
+
     return in_chans
 
 

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -254,7 +254,7 @@ class SemanticSegmentationTask(BaseTask):
         x = batch["image"]
         y = batch["mask"]
         model_output: ModelOutput = self(x)
-        
+        print(x.shape, model_output.output.shape, y.shape)        
         loss = self.val_loss_handler.compute_loss(model_output, y, self.criterion, self.aux_loss)
         self.val_loss_handler.log_loss(self.log, loss_dict=loss, batch_size=x.shape[0])
         y_hat_hard = to_segmentation_prediction(model_output)

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -254,7 +254,6 @@ class SemanticSegmentationTask(BaseTask):
         x = batch["image"]
         y = batch["mask"]
         model_output: ModelOutput = self(x)
-        print(x.shape, model_output.output.shape, y.shape)        
         loss = self.val_loss_handler.compute_loss(model_output, y, self.criterion, self.aux_loss)
         self.val_loss_handler.log_loss(self.log, loss_dict=loss, batch_size=x.shape[0])
         y_hat_hard = to_segmentation_prediction(model_output)


### PR DESCRIPTION
This minor adjust will guarantee that the number of input channels during the backbone instantiation is properly estimated, even when the bands are defined as "lists of subintervals" with integers as limits. 
This is particularly useful when we have a large number of input bands, for example:
```
dataset_bands:
 - [0, 285]
 input_bands:
- [0, 50]
- [85, 150]
```
