### PR TITLE
Overwrite default prithvi

### DIFF
--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -4,6 +4,7 @@
 import logging
 from functools import partial
 from pathlib import Path
+from collections import defaultdict
 
 import torch
 from timm.models import FeatureInfo
@@ -140,13 +141,22 @@ def create_prithvi_vit_100(
         "norm_layer": partial(nn.LayerNorm, eps=1e-6),
         "num_frames": 1,
     }
+
+    # It is possible to overwrite default parameters using 
+    # config file
+    kwargs_ = defaultdict()
+    kwargs_.update(model_args)
+    kwargs_.update(kwargs)
+    kwargs_ = dict(kwargs_)
+
     model = _create_prithvi(
         model_name,
         pretrained=pretrained,
         model_bands=bands,
         pretrained_bands=pretrained_bands,
-        **dict(model_args, **kwargs),
+        **kwargs_,
     )
+    
     return model
 
 


### PR DESCRIPTION
This is a suggestion to  more easily overwrite default options when instantiating Prithvi backbones, it means, user-defined parameters with the prefix "backbone" in the config YAML files can overwrite the default choices seen in methods as `create_prithvi_*`  inside `terratorch/models/backbones/prithvi_*.py`. If it's approved, we can extend it to Swin and definely remove these replicated methods. 