### PR TITLE
set default optimizer to None

### DIFF
--- a/terratorch/tasks/classification_tasks.py
+++ b/terratorch/tasks/classification_tasks.py
@@ -50,7 +50,7 @@ class ClassificationTask(BaseTask):
         ignore_index: int | None = None,
         lr: float = 0.001,
         # the following are optional so CLI doesnt need to pass them
-        optimizer: str | None = "torch.optim.Adam",
+        optimizer: str | None = None,
         optimizer_hparams: dict | None = None,
         scheduler: str | None = None,
         scheduler_hparams: dict | None = None,
@@ -80,7 +80,7 @@ class ClassificationTask(BaseTask):
             ignore_index (int | None, optional): Label to ignore in the loss computation. Defaults to None.
             lr (float, optional): Learning rate to be used. Defaults to 0.001.
             optimizer (str | None, optional): Name of optimizer class from torch.optim to be used.
-                Defaults to "Adam". Overriden by config / cli specification through LightningCLI.
+                If None, will use Adam. Defaults to None. Overriden by config / cli specification through LightningCLI.
             optimizer_hparams (dict | None): Parameters to be passed for instantiation of the optimizer.
                 Overriden by config / cli specification through LightningCLI.
             scheduler (str, optional): Name of Torch scheduler class from torch.optim.lr_scheduler
@@ -118,6 +118,9 @@ class ClassificationTask(BaseTask):
     def configure_optimizers(
         self,
     ) -> "lightning.pytorch.utilities.types.OptimizerLRSchedulerConfig":
+        optimizer = self.hparams["optimizer"]
+        if optimizer is None:
+            optimizer = "Adam"
         return optimizer_factory(
             self.hparams["optimizer"],
             self.hparams["lr"],

--- a/terratorch/tasks/regression_tasks.py
+++ b/terratorch/tasks/regression_tasks.py
@@ -139,7 +139,7 @@ class PixelwiseRegressionTask(BaseTask):
         ignore_index: int | None = None,
         lr: float = 0.001,
         # the following are optional so CLI doesnt need to pass them
-        optimizer: str | None = "Adam",
+        optimizer: str | None = None,
         optimizer_hparams: dict | None = None,
         scheduler: str | None = None,
         scheduler_hparams: dict | None = None,
@@ -166,7 +166,7 @@ class PixelwiseRegressionTask(BaseTask):
             ignore_index (int | None, optional): Label to ignore in the loss computation. Defaults to None.
             lr (float, optional): Learning rate to be used. Defaults to 0.001.
             optimizer (str | None, optional): Name of optimizer class from torch.optim to be used.
-                Defaults to "Adam". Overriden by config / cli specification through LightningCLI.
+                If None, will use Adam. Defaults to None. Overriden by config / cli specification through LightningCLI.
             optimizer_hparams (dict | None): Parameters to be passed for instantiation of the optimizer.
                 Overriden by config / cli specification through LightningCLI.
             scheduler (str, optional): Name of Torch scheduler class from torch.optim.lr_scheduler
@@ -208,6 +208,9 @@ class PixelwiseRegressionTask(BaseTask):
     def configure_optimizers(
         self,
     ) -> "lightning.pytorch.utilities.types.OptimizerLRSchedulerConfig":
+        optimizer = self.hparams["optimizer"]
+        if optimizer is None:
+            optimizer = "Adam"
         return optimizer_factory(
             self.hparams["optimizer"],
             self.hparams["lr"],

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -46,7 +46,7 @@ class SemanticSegmentationTask(BaseTask):
         ignore_index: int | None = None,
         lr: float = 0.001,
         # the following are optional so CLI doesnt need to pass them
-        optimizer: str | None = "Adam",
+        optimizer: str | None = None,
         optimizer_hparams: dict | None = None,
         scheduler: str | None = None,
         scheduler_hparams: dict | None = None,
@@ -77,7 +77,7 @@ class SemanticSegmentationTask(BaseTask):
             ignore_index (int | None, optional): Label to ignore in the loss computation. Defaults to None.
             lr (float, optional): Learning rate to be used. Defaults to 0.001.
             optimizer (str | None, optional): Name of optimizer class from torch.optim to be used.
-                Defaults to "Adam". Overriden by config / cli specification through LightningCLI.
+            If None, will use Adam. Defaults to None. Overriden by config / cli specification through LightningCLI.
             optimizer_hparams (dict | None): Parameters to be passed for instantiation of the optimizer.
                 Overriden by config / cli specification through LightningCLI.
             scheduler (str, optional): Name of Torch scheduler class from torch.optim.lr_scheduler
@@ -121,6 +121,9 @@ class SemanticSegmentationTask(BaseTask):
     def configure_optimizers(
         self,
     ) -> "lightning.pytorch.utilities.types.OptimizerLRSchedulerConfig":
+        optimizer = self.hparams["optimizer"]
+        if optimizer is None:
+            optimizer = "Adam"
         return optimizer_factory(
             self.hparams["optimizer"],
             self.hparams["lr"],
@@ -158,7 +161,9 @@ class SemanticSegmentationTask(BaseTask):
         elif loss == "dice":
             self.criterion = smp.losses.DiceLoss("multiclass", ignore_index=ignore_index)
         else:
-            exception_message = f"Loss type '{loss}' is not valid. Currently, supports 'ce', 'jaccard', 'dice' or 'focal' loss."
+            exception_message = (
+                f"Loss type '{loss}' is not valid. Currently, supports 'ce', 'jaccard', 'dice' or 'focal' loss."
+            )
             raise ValueError(exception_message)
 
     def configure_metrics(self) -> None:


### PR DESCRIPTION
After a finetuning with a config file, there is currently a confusing key in the output config file, under the model optimizer.

This is caused by LightningCLI, which automatically overrides the `configure_optimizers` method of the task and instead instantiates the optimizers and schedulers based on the keys `optimizer` and `lr_scheduler` at the root level of the config file.

The confusion occurs due to the default values for the optimizer in the tasks, which get output in the config file nonetheless. Thus, in the config file, we end up with two different optimizers, even though the one under `model.optimizer` is not used.

To remove this confusion, this PR replaces the default value in the constructor with `None`. Then, in `configure_optimizers`, if the value is `None`, it replaces it with `Adam` (the current default value).