### PR TITLE
The CLI argument  --data.init_args.predict_output_bands was missing

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -398,6 +398,7 @@ class LightningInferenceModel:
         config_path: Path,
         checkpoint_path: Path | None = None,
         predict_dataset_bands: list[str] | None = None,
+        predict_output_bands: list[str] | None = None,
     ):
         """
         Args:
@@ -415,6 +416,10 @@ class LightningInferenceModel:
         if predict_dataset_bands is not None:
             arguments.extend([ "--data.init_args.predict_dataset_bands",
             "[" + ",".join(predict_dataset_bands) + "]",])
+
+        if predict_output_bands is not None:
+            arguments.extend([ "--data.init_args.predict_output_bands",
+            "[" + ",".join(predict_output_bands) + "]",])
 
         cli = build_lightning_cli(arguments, run=False)
         trainer = cli.trainer

--- a/terratorch/datamodules/generic_pixel_wise_data_module.py
+++ b/terratorch/datamodules/generic_pixel_wise_data_module.py
@@ -427,7 +427,7 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
 
         self.dataset_bands = dataset_bands
         self.predict_dataset_bands = predict_dataset_bands if predict_dataset_bands else dataset_bands
-        self.predict_output_bands = predict_output_bands if predict_output_bands else dataset_bands
+        self.predict_output_bands = predict_output_bands if predict_output_bands else output_bands
         self.output_bands = output_bands
         self.rgb_indices = rgb_indices
 

--- a/terratorch/datamodules/generic_pixel_wise_data_module.py
+++ b/terratorch/datamodules/generic_pixel_wise_data_module.py
@@ -272,7 +272,7 @@ class GenericNonGeoSegmentationDataModule(NonGeoDataModule):
                 self.predict_root,
                 self.num_classes,
                 dataset_bands=self.predict_dataset_bands,
-                output_bands=self.output_bands,
+                output_bands=self.predict_output_bands,
                 constant_scale=self.constant_scale,
                 rgb_indices=self.rgb_indices,
                 transform=self.test_transform,
@@ -335,6 +335,7 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
         allow_substring_split_file: bool = True,
         dataset_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         predict_dataset_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
+        predict_output_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         output_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         constant_scale: float = 1,
         rgb_indices: list[int] | None = None,
@@ -426,6 +427,7 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
 
         self.dataset_bands = dataset_bands
         self.predict_dataset_bands = predict_dataset_bands if predict_dataset_bands else dataset_bands
+        self.predict_output_bands = predict_output_bands if predict_output_bands else dataset_bands
         self.output_bands = output_bands
         self.rgb_indices = rgb_indices
 
@@ -507,7 +509,7 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
             self.predict_dataset = self.dataset_class(
                 self.predict_root,
                 dataset_bands=self.predict_dataset_bands,
-                output_bands=self.output_bands,
+                output_bands=self.predict_output_bands,
                 constant_scale=self.constant_scale,
                 rgb_indices=self.rgb_indices,
                 transform=self.test_transform,


### PR DESCRIPTION
It explicitly adds the command line argument `--data.init_args.predict_output_bands` to specify the bands that must be used as input for a backbone. 