### PR TITLE
HOTFIX - fix predict output bands

### DIFF
--- a/terratorch/datamodules/generic_pixel_wise_data_module.py
+++ b/terratorch/datamodules/generic_pixel_wise_data_module.py
@@ -7,9 +7,10 @@ import os
 from collections.abc import Callable, Iterable
 from pathlib import Path
 from typing import Any
-import numpy as np
+
 import albumentations as A
 import kornia.augmentation as K
+import numpy as np
 import torch
 from torch import Tensor
 from torch.utils.data import DataLoader
@@ -18,6 +19,7 @@ from torchgeo.transforms import AugmentationSequential
 
 from terratorch.datasets import GenericNonGeoPixelwiseRegressionDataset, GenericNonGeoSegmentationDataset, HLSBands
 from terratorch.io.file import load_from_file_or_attribute
+
 
 def wrap_in_compose_is_list(transform_list):
     # set check shapes to false because of the multitemporal case
@@ -92,8 +94,9 @@ class GenericNonGeoSegmentationDataModule(NonGeoDataModule):
         ignore_split_file_extensions: bool = True,
         allow_substring_split_file: bool = True,
         dataset_bands: list[HLSBands | int | tuple[int, int] | str] | None = None,
-        predict_dataset_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         output_bands: list[HLSBands | int | tuple[int, int] | str] | None = None,
+        predict_dataset_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
+        predict_output_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         constant_scale: float = 1,
         rgb_indices: list[int] | None = None,
         train_transform: A.Compose | None | list[A.BasicTransform] = None,
@@ -133,9 +136,14 @@ class GenericNonGeoSegmentationDataModule(NonGeoDataModule):
             allow_substring_split_file (bool, optional): Whether the split files contain substrings
                 that must be present in file names to be included (as in mmsegmentation), or exact
                 matches (e.g. eurosat). Defaults to True.
-            dataset_bands (list[HLSBands | int] | None, optional): _description_. Defaults to None.
-            predict_dataset_bands (list[HLSBands | int] | None, optional): _description_. Defaults to None.
-            output_bands (list[HLSBands | int] | None, optional): _description_. Defaults to None.
+            dataset_bands (list[HLSBands | int] | None): Bands present in the dataset. Defaults to None.
+            output_bands (list[HLSBands | int] | None): Bands that should be output by the dataset.
+                Naming must match that of dataset_bands. Defaults to None.
+            predict_dataset_bands (list[HLSBands | int] | None): Overwrites dataset_bands
+                with this value at predict time.
+                Defaults to None, which does not overwrite.
+            predict_output_bands (list[HLSBands | int] | None): Overwrites output_bands
+                with this value at predict time. Defaults to None, which does not overwrite.
             constant_scale (float, optional): _description_. Defaults to 1.
             rgb_indices (list[int] | None, optional): _description_. Defaults to None.
             train_transform (Albumentations.Compose | None): Albumentations transform
@@ -185,6 +193,7 @@ class GenericNonGeoSegmentationDataModule(NonGeoDataModule):
 
         self.dataset_bands = dataset_bands
         self.predict_dataset_bands = predict_dataset_bands if predict_dataset_bands else dataset_bands
+        self.predict_output_bands = predict_output_bands if predict_output_bands else output_bands
         self.output_bands = output_bands
         self.rgb_indices = rgb_indices
         self.expand_temporal_dimension = expand_temporal_dimension
@@ -334,9 +343,9 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
         ignore_split_file_extensions: bool = True,
         allow_substring_split_file: bool = True,
         dataset_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
+        output_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         predict_dataset_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         predict_output_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
-        output_bands: list[HLSBands | int | tuple[int, int] | str ] | None = None,
         constant_scale: float = 1,
         rgb_indices: list[int] | None = None,
         train_transform: A.Compose | None | list[A.BasicTransform] = None,
@@ -375,9 +384,14 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
             allow_substring_split_file (bool, optional): Whether the split files contain substrings
                 that must be present in file names to be included (as in mmsegmentation), or exact
                 matches (e.g. eurosat). Defaults to True.
-            dataset_bands (list[HLSBands | int] | None, optional): _description_. Defaults to None.
-            predict_dataset_bands (list[HLSBands | int] | None, optional): _description_. Defaults to None.
-            output_bands (list[HLSBands | int] | None, optional): _description_. Defaults to None.
+            dataset_bands (list[HLSBands | int] | None): Bands present in the dataset. Defaults to None.
+            output_bands (list[HLSBands | int] | None): Bands that should be output by the dataset.
+                Naming must match that of dataset_bands. Defaults to None.
+            predict_dataset_bands (list[HLSBands | int] | None): Overwrites dataset_bands
+                with this value at predict time.
+                Defaults to None, which does not overwrite.
+            predict_output_bands (list[HLSBands | int] | None): Overwrites output_bands
+                with this value at predict time. Defaults to None, which does not overwrite.
             constant_scale (float, optional): _description_. Defaults to 1.
             rgb_indices (list[int] | None, optional): _description_. Defaults to None.
             train_transform (Albumentations.Compose | None): Albumentations transform

--- a/terratorch/datasets/generic_pixel_wise_dataset.py
+++ b/terratorch/datasets/generic_pixel_wise_dataset.py
@@ -140,6 +140,7 @@ class GenericPixelWiseDataset(NonGeoDataset, ABC):
         # self.transform = transform if transform else ToTensorV2()
 
         import warnings
+
         import rasterio
         warnings.filterwarnings("ignore", category=rasterio.errors.NotGeoreferencedWarning)
 


### PR DESCRIPTION
Add missing predict_output_bands in segmentation dataset.

There is a lot of code duplication with the regression and segmentation datasets and datamodules. It would be good to reduce this as much as possible to reduce the likelihood of these errors.

Once Catherine Wanjiru tests and confirms this fixes the issue, we should:

- Merge this PR
- Remove the most recent pypi release
- re-release with the merged code