### PR TITLE
Fix `FireScarsNonGeo.plot`

### DIFF
--- a/terratorch/datasets/fire_scars.py
+++ b/terratorch/datasets/fire_scars.py
@@ -65,6 +65,7 @@ class FireScarsNonGeo(NonGeoDataset):
         return self._plot_sample(
             image,
             label_mask,
+            num_classes=2,
             prediction=prediction_mask if showing_predictions else None,
             suptitle=suptitle,
         )


### PR DESCRIPTION
When calling `FireScarsNonGeo.plot` this crashed as `num_classes` is a required positional argument for `FireScarsNonGeo._plot_samples`. This PR fixes it by setting it to 2.