### PR TITLE
Automatically setting batch_size to 1 when the images don't have all the same dimensions

### DIFF
--- a/terratorch/datamodules/generic_pixel_wise_data_module.py
+++ b/terratorch/datamodules/generic_pixel_wise_data_module.py
@@ -20,6 +20,7 @@ from torchgeo.transforms import AugmentationSequential
 from terratorch.datasets import GenericNonGeoPixelwiseRegressionDataset, GenericNonGeoSegmentationDataset, HLSBands
 from terratorch.io.file import load_from_file_or_attribute
 
+from .utils import check_dataset_stackability
 
 def wrap_in_compose_is_list(transform_list):
     # set check shapes to false because of the multitemporal case
@@ -306,6 +307,9 @@ class GenericNonGeoSegmentationDataModule(NonGeoDataModule):
         """
         dataset = self._valid_attribute(f"{split}_dataset", "dataset")
         batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
+
+        batch_size = check_dataset_stackability(dataset, batch_size)
+
         return DataLoader(
             dataset=dataset,
             batch_size=batch_size,
@@ -532,7 +536,7 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
                 expand_temporal_dimension=self.expand_temporal_dimension,
                 reduce_zero_label=self.reduce_zero_label,
             )
-
+       
     def _dataloader_factory(self, split: str) -> DataLoader[dict[str, Tensor]]:
         """Implement one or more PyTorch DataLoaders.
 
@@ -548,6 +552,9 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
         """
         dataset = self._valid_attribute(f"{split}_dataset", "dataset")
         batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
+
+        batch_size = check_dataset_stackability(dataset, batch_size)
+
         return DataLoader(
             dataset=dataset,
             batch_size=batch_size,

--- a/terratorch/datamodules/generic_scalar_label_data_module.py
+++ b/terratorch/datamodules/generic_scalar_label_data_module.py
@@ -22,6 +22,7 @@ from terratorch.datasets import (
 )
 from terratorch.io.file import load_from_file_or_attribute
 
+from .utils import check_dataset_stackability
 
 def wrap_in_compose_is_list(transform_list):
     # set check shapes to false because of the multitemporal case
@@ -242,6 +243,9 @@ class GenericNonGeoClassificationDataModule(NonGeoDataModule):
         """
         dataset = self._valid_attribute(f"{split}_dataset", "dataset")
         batch_size = self._valid_attribute(f"{split}_batch_size", "batch_size")
+        
+        batch_size = check_dataset_stackability(dataset, batch_size)
+
         return DataLoader(
             dataset=dataset,
             batch_size=batch_size,

--- a/terratorch/datamodules/utils.py
+++ b/terratorch/datamodules/utils.py
@@ -1,10 +1,22 @@
 # Copyright contributors to the Terratorch project
 
 from typing import Iterable
-
+import numpy as np
 import albumentations as A
 
 
 def wrap_in_compose_is_list(transform_list):
     # set check shapes to false because of the multitemporal case
     return A.Compose(transform_list, is_check_shapes=False) if isinstance(transform_list, Iterable) else transform_list
+
+def check_dataset_stackability(dataset, batch_size) -> bool:
+
+    shapes = np.array([item["image"].shape for item in dataset])
+    
+    if np.array_equal(shapes.max(0), shapes.min(0)):
+        return batch_size
+    else:
+        print("The batch samples can't be stacked, since they don't have the same dimensions. Setting batch_size=1.")
+        return 1
+    
+


### PR DESCRIPTION
When a a list of images with different dimensions is passed to a dataloader, the batch is automatically set to 1 to avoid stacking issues. 