### PR TITLE
add back geobench dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/required.txt -r requirements/test.txt
+          pip install -r requirements/required.txt -r requirements/test.txt -r requirements/optional.txt
       - name: List pip dependencies
         run: pip list
       - name: Test with pytest
@@ -50,7 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements/required.txt -r requirements/test.txt
+          pip install -r requirements/required.txt -r requirements/test.txt -r requirements/optional.txt
           pip install git+https://github.com/NASA-IMPACT/Prithvi-WxC.git
           pip install git+https://github.com/IBM/granite-wxc.git
       - name: List pip dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ dev = [
   "mkdocstrings[python]"
 ]
 
+geobench = [
+  "geobench"
+]
+
 test = [
   "coverage",
   "pytest"

--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -1,0 +1,8 @@
+geobench==1.0.0
+#mmcv==2.0.0
+#ftfy
+#regex
+#openmim
+
+# Lastly, install mmsegmentation using mim:
+# mim mmsegmentation


### PR DESCRIPTION
At least one of the geobench datasets sneakily uses geobench with `ast.literal_eval`. This snuck by because there is no `import` statement...

Added it back, and placed it in a new requirements/optional.txt