### PR TITLE
Fix `freeze_decoder`

### DIFF
--- a/terratorch/models/pixel_wise_model.py
+++ b/terratorch/models/pixel_wise_model.py
@@ -83,7 +83,7 @@ class PixelWiseModel(Model, SegmentationModel):
         freeze_module(self.encoder)
 
     def freeze_decoder(self):
-        freeze_module(self.encoder)
+        freeze_module(self.decoder)
         freeze_module(self.head)
 
     def _single_embedding_output(self, features: torch.Tensor) -> torch.Tensor:

--- a/terratorch/models/scalar_output_model.py
+++ b/terratorch/models/scalar_output_model.py
@@ -65,7 +65,7 @@ class ScalarOutputModel(Model, SegmentationModel):
         freeze_module(self.encoder)
 
     def freeze_decoder(self):
-        freeze_module(self.encoder)
+        freeze_module(self.decoder)
         freeze_module(self.head)
 
     # TODO: do this properly


### PR DESCRIPTION
When freezing the decoder in `PixelWiseModel` and `ScalarOutputModel`, the `encoder` and the `head` were actually being frozen instead of the `decoder` and the `head`.