### PR TITLE
import custom modules from  dir

### DIFF
--- a/docs/models.md
+++ b/docs/models.md
@@ -97,3 +97,9 @@ class SMPModelWrapper(Model, nn.Module):
     def freeze_decoder(self):
         pass
 ```
+
+# Custom modules with CLI
+
+Custom modules must be in the import path in order to be registered in the appropriate registries. 
+
+In order to do this without modifying the code when using the CLI, you may place your modules under a `custom_modules` directory. This must be in the directory from which you execute terratorch.


### PR DESCRIPTION
Allow users to add backbones (or other components) without needing to edit the source code. 

All code in the directory `custom_modules` will be imported, so custom modules may be registered