### PR TITLE
Save/batch predictions

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -521,7 +521,7 @@ class LightningInferenceModel:
         Returns:
             A torch tensor with the prediction
         """
-        print("USING ME")
+
         with tempfile.TemporaryDirectory() as tmpdir:
             os.symlink(file_path, os.path.join(tmpdir, os.path.basename(file_path)))
             prediction, file_name = self.inference_on_dir(

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -505,6 +505,7 @@ class LightningInferenceModel:
             A tuple with a torch tensor with all predictions and a list of corresponding input file paths
 
         """
+
         if data_root:
             self.datamodule.predict_root = data_root
         predictions = self.trainer.predict(model=self.model, datamodule=self.datamodule, return_predictions=True)

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -114,7 +114,7 @@ class CustomWriter(BasePredictionWriter):
     def write_on_batch_end(self, trainer, pl_module, prediction, batch_indices, batch, batch_idx, dataloader_idx):  # noqa: ARG002
         # this will create N (num processes) files in `output_dir` each containing
         # the predictions of it's respective rank
-        print("doing.")
+
         # by default take self.output_dir. If None, look for one in trainer
         if self.output_dir is None:
             try:
@@ -133,7 +133,6 @@ class CustomWriter(BasePredictionWriter):
 
         for prediction, file_name in zip(torch.unbind(pred_batch, dim=0), filename_batch, strict=False):
             save_prediction(prediction, file_name, output_dir, dtype=trainer.out_dtype)
-
 
     def write_on_epoch_end(self, trainer, pl_module, predictions, batch_indices):  # noqa: ARG002
         # this will create N (num processes) files in `output_dir` each containing

--- a/terratorch/datamodules/generic_pixel_wise_data_module.py
+++ b/terratorch/datamodules/generic_pixel_wise_data_module.py
@@ -526,6 +526,7 @@ class GenericNonGeoPixelwiseRegressionDataModule(NonGeoDataModule):
         if stage in ["predict"] and self.predict_root:
             self.predict_dataset = self.dataset_class(
                 self.predict_root,
+                image_grep=self.img_grep,
                 dataset_bands=self.predict_dataset_bands,
                 output_bands=self.predict_output_bands,
                 constant_scale=self.constant_scale,


### PR DESCRIPTION
Generate the outputs at the end of the batch during inference. It will allow the images being gradually generated instead of being all created a single time.  