### PR TITLE
A batch script for running with multi-nodes / multi-GPUs on Slurm environment

### DIFF
--- a/examples/scripts/sen1floods11_vit_fit.sh
+++ b/examples/scripts/sen1floods11_vit_fit.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+# We assue following environ variables are available from Slurm:
+#   SLURM_JOB_NUM_NODES   - Number of nodes
+#   SLURM_NTASKS_PER_NODE - Nuber of GPUs (tasks) per node
+
+cat <<EOF
+echo "$0: ${SLURM_PROCID} Debug info ----------"
+SLURM_JOB_ID="${SLURM_JOB_ID}"
+SLURM_JOB_NAME="${SLURM_JOB_NAME}"
+SLURM_JOB_PARTITION="${SLURM_JOB_PARTITION}"
+SLURM_JOB_NUM_NODES="${SLURM_JOB_NUM_NODES}"
+SLURM_JOB_ID="${SLURM_JOB_ID}"
+SLURM_JOB_NODELIST="${SLURM_JOB_NODELIST}"
+SLURM_JOB_CPUS_PER_NODE="${SLURM_JOB_CPUS_PER_NODE}"
+SLURM_JOB_ACCOUNT="${SLURM_JOB_ACCOUNT}"
+HOST=`hostname`
+SLURM_GPUS_ON_NODE="${SLURM_GPUS_ON_NODE}"
+SLURM_NTASKS_PER_NODE="${SLURM_NTASKS_PER_NODE}"
+SLURM_CPUS_PER_TASK="${SLURM_CPUS_PER_TASK}"
+SLURM_PROCID="${SLURM_PROCID}" # global_rank
+SLURM_LOCALID="${SLURM_LOCALID}" # local_rank
+SLURM_NODEID="${SLURM_NODEID}" # node_rank
+CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}"
+SLURM_NTASKS="${SLURM_NTASKS}"
+echo "=========="
+EOF
+
+#export PYTHONFAULTHANDLER=1
+#export JSONARGPARSE_DEBUG=true
+#export NCCL_DEBUG=WARN
+
+CONF=sen1floods11_vit
+TASK=fit
+ROOT_DIR=${CONF}_${TASK}_${SLURM_JOB_NUM_NODES}x${SLURM_NTASKS_PER_NODE}
+YAML_PATH=../confs/${CONF}.yaml
+# Download Sen1Floods11 data as described in https://github.com/IBM/terratorch/blob/main/examples/confs/README.md
+# and set the directory below.
+SEN1FLOODS11_ROOT=YOUR_DATA_REPOSITORY
+
+time terratorch ${TASK} --config ${YAML_PATH} \
+     --trainer.num_nodes ${SLURM_JOB_NUM_NODES} \
+     --trainer.devices ${SLURM_NTASKS_PER_NODE} \
+     --trainer.default_root_dir ${ROOT_DIR} \
+     --data.init_args.train_data_root ${SEN1FLOODS11_ROOT}/v1.1/data/flood_events/HandLabeled/S2Hand/ \
+     --data.init_args.train_label_data_root ${SEN1FLOODS11_ROOT}/v1.1/data/flood_events/HandLabeled/LabelHand \
+     --data.init_args.val_data_root ${SEN1FLOODS11_ROOT}/v1.1/data/flood_events/HandLabeled/S2Hand/ \
+     --data.init_args.val_label_data_root ${SEN1FLOODS11_ROOT}/v1.1/data/flood_events/HandLabeled/LabelHand \
+     --data.init_args.test_data_root ${SEN1FLOODS11_ROOT}/v1.1/data/flood_events/HandLabeled/S2Hand/ \
+     --data.init_args.test_label_data_root ${SEN1FLOODS11_ROOT}/v1.1/data/flood_events/HandLabeled/LabelHand \
+     --data.init_args.train_split ${SEN1FLOODS11_ROOT}/v1.1/splits/flood_handlabeled/flood_train_data.txt \
+     --data.init_args.test_split ${SEN1FLOODS11_ROOT}/v1.1/splits/flood_handlabeled/flood_test_data.txt \
+     --data.init_args.val_split ${SEN1FLOODS11_ROOT}/v1.1/splits/flood_handlabeled/flood_valid_data.txt

--- a/examples/scripts/slurm_submit.sh
+++ b/examples/scripts/slurm_submit.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# slurm_submit.sh - Batch script for Slurm environment
+# Usage:
+#   $ slurm_submit.sh <script-name> <num-nodes> <num-gpus>
+#   where
+#     script-name: Name of script to run in parallel (e.g. sen1floods11_vit_fit.sh)
+#     num-nodes:   Number of nodes (1, 2, ...)
+#     num-gpus     Number of GPUs in a node (1, 2, 3, or 4)
+script_name=$1
+num_nodes=$2
+num_gpus=$3
+logfile="log/slurm-%j.out"
+if [ $# -ne 3 ]; then
+    echo "Usage: %0 <script-name> <num-nodes> <num-gpus>"
+    exit 1
+fi
+# Used to set CUDA_VISIBLE_DEVICES so that all GPUs on a node can be accessible from all tasks on the node
+devices=("" "0" "0,1" "0,1,2" "0,1,2,3")
+
+sbatch -o ${logfile} -e ${logfile} <<EOF
+#!/bin/sh
+#SBATCH --account=geofm4eo
+#SBATCH --partition=booster
+#SBATCH --job-name "terratorch"
+#SBATCH --nodes=${num_nodes}
+#SBATCH --ntasks-per-node=${num_gpus}
+#SBATCH --gres=gpu:${num_gpus}
+#SBATCH --cpus-per-task=8
+#SBATCH --time=04:00:00
+
+export CUDA_VISIBLE_DEVICES=${devices[$num_gpus]}
+srun -o ${logfile} -e ${logfile} ${script_name}
+EOF


### PR DESCRIPTION
`examples/scripts/slurm_submit.sh` - A batch script to submit a job with multi-nodes / multi-GPUs. Totally `num-nodes` x `num-gpus` of tasks are created on `num-nodes` nodes. `CUDA_VISIBLE_DEVICES` is set up so that all GPUs on a node can be accessible from all tasks on the node.

```
# slurm_submit.sh - Batch script for Slurm environment                                                                                                        
# Usage:                                                                                                                                                      
#   $ slurm_submit.sh <script-name> <num-nodes> <num-gpus>                                                                                                    
#   where                                                                                                                                                     
#     script-name: Name of script to run in parallel (e.g. sen1floods11_vit_fit.sh)                                                                           
#     num-nodes:   Number of nodes (1, 2, ...)                                                                                                                
#     num-gpus     Number of GPUs in a node (1, 2, 3, or 4)
```
`examples/scripts/sen1floods11_vit_fit.sh` is a sample workload which executes fit operation for sen1floods11_vit.yaml model. It retrieves number of nodes and GPUs from SLURM environment variables and pass them to the trainer via command line arguments (e.g. `--trainer.num_nodes`).
Also data path is setup and passed to the dataloader via command line arguments (e.g. `--data.init_args.train_data_root` so that `confs/sen1floods11_vit.yaml` file is used without any modification.

Sample run
- Download Sen1floods11 data as described in https://github.com/IBM/terratorch/blob/main/examples/confs/README.md.
- Edit examples/scripts/sen1floods11_vit_fit.sh and set SEN1FLOODS11_ROOT to point to the directory you downloaded above.
- Run following command
```
$ ./slurm_submit.sh sen1floods11_vit_fit.sh 4 4
```
The result will be stored in `sen1floods11_vit_fit_4x4/lightning_logs/version_JOBID/` and fog file is `log/slurm-JOBID.out`.

Tested on JUWELS Booster cluster at FZJ (https://apps.fz-juelich.de/jsc/hps/juwels/booster-overview.html).



