### PR TITLE
Fix: Remove filter warnings in clay

### DIFF
--- a/terratorch/models/backbones/clay_v1/embedder.py
+++ b/terratorch/models/backbones/clay_v1/embedder.py
@@ -11,8 +11,6 @@ from timm.models._registry import generate_default_cfgs, register_model
 
 from terratorch.models.backbones.clay_v1.modules import EmbeddingEncoder, Datacuber
 
-warnings.filterwarnings("ignore", category=UserWarning)
-
 
 default_cfgs = generate_default_cfgs(
     {


### PR DESCRIPTION
This line was always run when importing `terratorch` making it ignore all `UserWarning`s.