### PR TITLE
Change Clay forward signature to work with tasks

### DIFF
--- a/terratorch/models/backbones/clay_v1/embedder.py
+++ b/terratorch/models/backbones/clay_v1/embedder.py
@@ -37,11 +37,8 @@ class Embedder(nn.Module):
         self.num_frames = num_frames
         self.bands = bands
 
-        if kwargs.get("datacuber", True) is not None:
-            self.datacuber = Datacuber(bands=bands)
-        else:
-            self.datacuber = None
-            
+        self.datacuber = Datacuber(bands=bands)
+
         # TODO: add support for various clay versions
         self.clay_encoder = (
             EmbeddingEncoder(  # Default parameters for the Clay base model
@@ -96,11 +93,15 @@ class Embedder(nn.Module):
         }
         return state_dict
 
-    def forward_features(self, x):
-        if self.datacuber is not None:
-            datacube = self.datacuber(x)
-        else:
-            datacube = x
+    def forward_features(
+        self,
+        x: torch.Tensor,
+        time: torch.Tensor | None = None,
+        latlon: torch.Tensor | None = None,
+        waves: torch.Tensor | None = None,
+        gsd: float | None = None,
+    ):
+        datacube = self.datacuber(x=x, time=time, latlon=latlon, waves=waves, gsd=gsd)
         embeddings = self.clay_encoder(datacube)
 
         # TODO: actually return features individually

--- a/terratorch/models/backbones/clay_v1/modules.py
+++ b/terratorch/models/backbones/clay_v1/modules.py
@@ -516,10 +516,10 @@ class Datacuber(nn.Module):
     ) -> dict[str, torch.Tensor | float]:
         datacube: dict[str, torch.Tensor | float] = {}
         datacube["pixels"] = x
-        datacube["time"] = torch.zeros((x.shape[0], 4)) if time is None else time
-        datacube["latlon"] = torch.zeros((x.shape[0], 4)) if latlon is None else latlon
+        datacube["time"] = torch.zeros((x.shape[0], 4), device=x.device) if time is None else time
+        datacube["latlon"] = torch.zeros((x.shape[0], 4), device=x.device) if latlon is None else latlon
         datacube["gsd"] = 1.0 if gsd is None else gsd
-        datacube["waves"] = self._parse_wavelengths(self.bands, x.shape[1]) if waves is None else waves
+        datacube["waves"] = self._parse_wavelengths(self.bands, x.shape[1]).to(x.device) if waves is None else waves
         return datacube
 
     def _parse_wavelengths(self, bands, channels):

--- a/terratorch/models/backbones/clay_v1/modules.py
+++ b/terratorch/models/backbones/clay_v1/modules.py
@@ -503,34 +503,28 @@ class DynamicEmbedding(nn.Module):
 
 
 class Datacuber(nn.Module):
-    def __init__(self,
-                 bands=None) -> None:
+    def __init__(self, bands=None) -> None:
         super().__init__()
         self.bands = bands
 
-    def forward(self, x, **kwargs):
-        if not isinstance(x, dict):
-            datacube = {}
-            datacube['pixels'] = x
-            datacube['time'] = torch.zeros((x.shape[0], 4))
-            datacube['latlon'] = torch.zeros((x.shape[0], 4))
-            datacube['gsd'] = 1.0
-            datacube['waves'] = self._parse_wavelengths(self.bands, x.shape[1])
-            return datacube
-        else:
-            assert "pixels" in datacube
-            if "time" not in datacube:
-                datacube['time'] = torch.zeros((x.shape[0], 4))
-            if "latlon" not in datacube:
-                datacube['latlon'] = torch.zeros((x.shape[0], 4))
-            if "gsd" not in datacube:
-                datacube["gsd"] = 1.0
-            if "waves" not in datacube:
-                datacube['waves'] = self._parse_wavelengths(self.bands, x.shape[1])
-            return x
-        
+    def forward(
+        self,
+        x: torch.Tensor,
+        time: torch.Tensor | None = None,
+        latlon: torch.Tensor | None = None,
+        waves: torch.Tensor | None = None,
+        gsd: float | None = None,
+    ) -> dict[str, torch.Tensor | float]:
+        datacube: dict[str, torch.Tensor | float] = {}
+        datacube["pixels"] = x
+        datacube["time"] = torch.zeros((x.shape[0], 4)) if time is None else time
+        datacube["latlon"] = torch.zeros((x.shape[0], 4)) if latlon is None else latlon
+        datacube["gsd"] = 1.0 if gsd is None else gsd
+        datacube["waves"] = self._parse_wavelengths(self.bands, x.shape[1]) if waves is None else waves
+        return datacube
+
     def _parse_wavelengths(self, bands, channels):
-        if bands is not None and all([_ in WAVELENGTHS for  _ in bands]):
+        if bands is not None and all([_ in WAVELENGTHS for _ in bands]):
             return torch.tensor([WAVELENGTHS[_] for _ in bands])
         else:
             return torch.zeros(channels)

--- a/terratorch/models/backbones/clay_v1/modules.py
+++ b/terratorch/models/backbones/clay_v1/modules.py
@@ -461,7 +461,6 @@ class DynamicEmbedding(nn.Module):
 
     def forward(self, batch, waves):
         waves = posemb_sincos_1d(waves, self.wave_dim)
-        waves = waves.to(batch.device)
         waves = self.fclayer(waves)
         weight, bias = self.weight_generator(waves)
 

--- a/terratorch/models/backbones/clay_v1/utils.py
+++ b/terratorch/models/backbones/clay_v1/utils.py
@@ -30,12 +30,10 @@ def posemb_sincos_2d_with_gsd(
 
 
 def posemb_sincos_1d(pos, dim, temperature: int = 10000, dtype=torch.float32):
-    assert (
-        dim % 2 == 0
-    ), "Feature dimension must be a multiple of 2 for sincos embedding"
+    assert dim % 2 == 0, "Feature dimension must be a multiple of 2 for sincos embedding"
     pos = torch.arange(pos) if isinstance(pos, int) else pos
 
-    omega = torch.arange(dim // 2) / (dim // 2 - 1)
+    omega = torch.arange(dim // 2).to(pos) / (dim // 2 - 1)
     omega = 1.0 / (temperature**omega)
 
     scaled_pos = pos[:, None] * omega[None, :]


### PR DESCRIPTION
All tasks assume the batch returned by the dataloader is a dictionary with an `"image"` key, the corresponding y label (either `"mask"` or `"label"`) and the rest of elements of the dictionary are passed as keyword arguments to the model, see an example [here](https://github.com/IBM/terratorch/blob/308477ab2784160d80b10fcd4b5240a1e671baf4/terratorch/tasks/segmentation_tasks.py#L236-L241).
For this reason, it was not possible to pass the metadata to Clay using a dictionary (which is what Clay expected).

This PR modifies Clay to accept the metadata as keyword arguments instead of a dict and the `Embedder` constructs the dictionary using a `Datacuber`.

It also fixes a computation of the positional embedding when a device different than `cpu` is used.