### PR TITLE
Fix `state_dict` redefinition

### DIFF
--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -60,7 +60,7 @@ def checkpoint_filter_fn_vit(
         else:
             clean_dict[k] = v
 
-        state_dict = clean_dict
+    state_dict = clean_dict
 
     state_dict = select_patch_embed_weights(state_dict, model, pretrained_bands, model_bands)
 
@@ -93,7 +93,7 @@ def checkpoint_filter_fn_mae(
         else:
             clean_dict["encoder." + k] = v
 
-        state_dict = clean_dict
+    state_dict = clean_dict
 
     state_dict = select_patch_embed_weights(state_dict, model, pretrained_bands, model_bands)
 


### PR DESCRIPTION
When filtering the checkpoint weights, `state_dict` was being redefined while looping through it. This did not cause any issue or bug as it was never referenced again inside the loop and python "locks" the items it when starting iterating over it but could give future problems if the code was changed.

CC: @blumenstiel 