### PR TITLE
Fix clay `hf_hub_filename`

### DIFF
--- a/terratorch/models/backbones/clay_v1/embedder.py
+++ b/terratorch/models/backbones/clay_v1/embedder.py
@@ -16,7 +16,7 @@ default_cfgs = generate_default_cfgs(
     {
         "clay_v1_base": {
             "hf_hub_id": "made-with-clay/Clay",
-            "hf_hub_filename": "clay-v1-base.ckpt"
+            "hf_hub_filename": "v1/clay-v1-base.ckpt",
         }
     }
 )


### PR DESCRIPTION
In huggingface, they recently released Clay v1.5 and restructured the structure of their repo, see [here](https://huggingface.co/made-with-clay/Clay/commits/main). This PR fixes the `hf_hub_filename` to pull from the correct url.