### PR TITLE
Remove fallback by error with pretrained weights

### DIFF
--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -218,7 +218,6 @@ def _create_prithvi(
         model_args = prithvi_default_cfgs[variant].copy()
         model_args.update(kwargs)
 
-    # When the pretrained configuration is not available in HF, we shift to pretrained=False
     try:
         model = build_model_with_cfg(
             prithvi_model_class,
@@ -228,16 +227,13 @@ def _create_prithvi(
             pretrained_strict=True,
             **model_args,
         )
-    except RuntimeError:
-        logger.warning(f"No pretrained configuration was found for the model {variant}.")
-        model = build_model_with_cfg(
-            prithvi_model_class,
-            variant,
-            False,
-            pretrained_filter_fn=checkpoint_filter_wrapper_fn,
-            pretrained_strict=True,
-            **model_args,
-        )
+    except RuntimeError as e:
+        if pretrained:
+            logger.error(f"Failed to initialize the pre-trained model {variant} via timm, "
+                         f"consider running the code with pretrained=False.")
+        else:
+            logger.error(f"Failed to initialize the model {variant} via timm.")
+        raise e
 
     if encoder_only:
         default_out_indices = list(range(len(model.blocks)))


### PR DESCRIPTION
Users might not see the warning, that random weights loaded. Therefore, it is better to raise an error.