### PR TITLE
Add deprecation warning for `scale_modules`

### DIFF
--- a/terratorch/models/decoders/upernet_decoder.py
+++ b/terratorch/models/decoders/upernet_decoder.py
@@ -37,7 +37,7 @@ class UperNetDecoder(nn.Module):
             warnings.warn(
                 "DeprecationWarning: scale_modules is deprecated and will be removed in future versions. "
                 "Use LearnedInterpolateToPyramidal neck instead.",
-                stacklevel=2,
+                stacklevel=1,
             )
 
         self.scale_modules = scale_modules

--- a/terratorch/models/decoders/upernet_decoder.py
+++ b/terratorch/models/decoders/upernet_decoder.py
@@ -1,9 +1,11 @@
 import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
+import warnings
 
 from terratorch.registry import TERRATORCH_DECODER_REGISTRY
 from .utils import ConvModule
+
 
 # Adapted from MMSegmentation
 @TERRATORCH_DECODER_REGISTRY.register
@@ -16,7 +18,7 @@ class UperNetDecoder(nn.Module):
         pool_scales: tuple[int] = (1, 2, 3, 6),
         channels: int = 256,
         align_corners: bool = True,  # noqa: FBT001, FBT002
-        scale_modules: bool = False
+        scale_modules: bool = False,
     ):
         """Constructor
 
@@ -30,6 +32,14 @@ class UperNetDecoder(nn.Module):
                 Defaults to False.
         """
         super().__init__()
+        if scale_modules:
+            # TODO: remove scale_modules before v1?
+            warnings.warn(
+                "DeprecationWarning: scale_modules is deprecated and will be removed in future versions. "
+                "Use LearnedInterpolateToPyramidal neck instead.",
+                stacklevel=2,
+            )
+
         self.scale_modules = scale_modules
         if scale_modules:
             self.fpn1 = nn.Sequential(


### PR DESCRIPTION
As discussed with @blumenstiel in #352 I would suggest to deprecate `scale_modules` from the `UperNetDecoder`. This parameter was implemented before there were necks and therefore it was necessary to scale the features inside the decoder. With the introduction of necks this can be done with the `LearnedInterpolateToPyramidal` neck and I believe it's better to use a neck as it should not be part of the decoder.
I would suggest to fully remove it before releasing v1 but we give some warning before in case people use it.