### PR TITLE
Fix timm config loading for prithvi

### DIFF
--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -208,7 +208,7 @@ def _create_prithvi(
                                             f"(pretrained models: {default_cfgs.keys()})")
         # Load pre-trained config from hf
         try:
-            model_args, _ = load_model_config_from_hf(default_cfgs[variant].default.hf_hub_id)
+            model_args = load_model_config_from_hf(default_cfgs[variant].default.hf_hub_id)[0]
             model_args.update(kwargs)
         except:
             logger.warning(f"No pretrained configuration was found on HuggingFace for the model {variant}."


### PR DESCRIPTION
Timm changed the function `load_model_config_from_hf` in version 0.9.11 and returns 3 values, which results in an error with the current code.

Thanks @fmartiescofet for pointing out this error!