### PR TITLE
Replacing hash-version with stable torchgeo==0.6.2 and segmentation-models-pytorch==0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ dependencies = [
 torchgeo = [
   "torch==2.4.1",
   "torchvision==0.19.1",
-  "torchgeo @ git+https://github.com/microsoft/torchgeo.git@fedf99375535f801565856cd774bfa9e5a251d55",
+  "torchgeo==0.6.2", #@ git+https://github.com/microsoft/torchgeo.git@fedf99375535f801565856cd774bfa9e5a251d55",
   "rioxarray>=0.15.0",
   "albumentations==1.3.1",
   "albucore<=0.0.16",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ torchgeo = [
   "torch==2.4.1",
   "torchvision==0.19.1",
   "torchgeo==0.6.2", #@ git+https://github.com/microsoft/torchgeo.git@fedf99375535f801565856cd774bfa9e5a251d55",
+  "segmentation-models-pytorch==0.4.0",
   "rioxarray>=0.15.0",
   "albumentations==1.3.1",
   "albucore<=0.0.16",

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -11,7 +11,7 @@ lightly==1.5.13
 h5py==3.10.0
 mlflow==2.14.3
 lightning==2.4.0
-git+https://github.com/qubvel-org/segmentation_models.pytorch.git@3952e1f8e9684a385a81e30381b8fb5b1ac086cf
+segmentation-models-pytorch==0.4.0 #git+https://github.com/qubvel-org/segmentation_models.pytorch.git@3952e1f8e9684a385a81e30381b8fb5b1ac086cf
 timm==1.0.11
 numpy==1.26.4
 jsonargparse==4.32.0

--- a/requirements/required.txt
+++ b/requirements/required.txt
@@ -1,5 +1,4 @@
-#torchgeo==0.7.0.dev0
-git+https://github.com/microsoft/torchgeo.git@fedf99375535f801565856cd774bfa9e5a251d55
+torchgeo==0.6.2
 rioxarray==0.15.0
 albumentations==1.3.1
 albucore<=0.0.16


### PR DESCRIPTION
These releases already encompass the features required by the hash-versions currently used. 