### PR TITLE
Unpin exact `jsonargparse` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "torchmetrics",
   "geopandas",
   "lightly",
-  "jsonargparse==4.32.0",
+  "jsonargparse<=4.35.0",
   "h5py",
   "mlflow",
   "lightning",


### PR DESCRIPTION
The latest `jsonargparse` version which works is `4.35.0`, we should not restrict to `4.32.0`.