### PR TITLE
Fix prithvi

### DIFF
--- a/examples/confs/sen1floods11_vit_local_ckpt.yaml
+++ b/examples/confs/sen1floods11_vit_local_ckpt.yaml
@@ -86,7 +86,7 @@ model:
     model_args:
       backbone: prithvi_eo_v2_300
       backbone_pretrained: false
-      backbone_ckpt_path: examples/Prithvi_100M.pt
+      backbone_ckpt_path: examples/Prithvi_EO_V2_300M.pt
       backbone_drop_path: 0.1
       backbone_bands:
         - BLUE

--- a/terratorch/models/backbones/prithvi_mae.py
+++ b/terratorch/models/backbones/prithvi_mae.py
@@ -251,7 +251,6 @@ class PrithviViT(nn.Module):
         self.in_chans = in_chans
         self.num_frames = num_frames
         self.embed_dim = embed_dim
-        self.out_channels = [embed_dim] * depth
         self.img_size = to_2tuple(img_size)
         if isinstance(patch_size, int):
             patch_size = (1, patch_size, patch_size)
@@ -263,6 +262,7 @@ class PrithviViT(nn.Module):
             in_chans=in_chans,
             embed_dim=embed_dim,
         )
+        self.out_channels = [embed_dim * self.patch_embed.grid_size[0]] * depth
 
         # Optional temporal and location embedding
         coords_encoding = coords_encoding or []

--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -213,24 +213,32 @@ def _create_prithvi(
 
     model = prithvi_model_class(**model_args)
 
-    if ckpt_path is not None:
-        # Load model from checkpoint
-        state_dict = torch.load(ckpt_path, map_location="cpu", weights_only=True)
-        state_dict = checkpoint_filter_wrapper_fn(state_dict, model, pretrained_bands, model_bands)
-        model.load_state_dict(state_dict, strict=False)
-    elif pretrained:
-        try:
-            # Download config.json to count model downloads
-            _ = hf_hub_download(repo_id=pretrained_weights[variant]["hf_hub_id"], filename="config.json")
-            # Load model from Hugging Face
-            pretrained_path = hf_hub_download(repo_id=pretrained_weights[variant]["hf_hub_id"],
-                                              filename=pretrained_weights[variant]["hf_hub_filename"])
-            state_dict = torch.load(pretrained_path, map_location="cpu", weights_only=True)
+    if pretrained:
+        if ckpt_path is not None:
+            # Load model from checkpoint
+            state_dict = torch.load(ckpt_path, map_location="cpu", weights_only=True)
             state_dict = checkpoint_filter_wrapper_fn(state_dict, model, pretrained_bands, model_bands)
-            model.load_state_dict(state_dict, strict=True)
-        except RuntimeError as e:
-            logger.error(f"Failed to load the pre-trained weights for {variant}.")
-            raise e
+            loaded_keys = model.load_state_dict(state_dict, strict=False)
+            if loaded_keys.missing_keys:
+                logger.warning(f"Missing keys in ckpt_path {ckpt_path}: {loaded_keys.missing_keys}")
+            if loaded_keys.unexpected_keys:
+                logger.warning(f"Missing keys in ckpt_path {ckpt_path}: {loaded_keys.missing_keys}")
+        else:
+            try:
+                # Download config.json to count model downloads
+                _ = hf_hub_download(repo_id=pretrained_weights[variant]["hf_hub_id"], filename="config.json")
+                # Load model from Hugging Face
+                pretrained_path = hf_hub_download(repo_id=pretrained_weights[variant]["hf_hub_id"],
+                                                  filename=pretrained_weights[variant]["hf_hub_filename"])
+                state_dict = torch.load(pretrained_path, map_location="cpu", weights_only=True)
+                state_dict = checkpoint_filter_wrapper_fn(state_dict, model, pretrained_bands, model_bands)
+                model.load_state_dict(state_dict, strict=True)
+            except RuntimeError as e:
+                logger.error(f"Failed to load the pre-trained weights for {variant}.")
+                raise e
+
+    model.model_bands = model_bands
+    model.pretrained_bands = pretrained_bands
 
     assert encoder_only or "out_indices" not in kwargs, "out_indices provided for a MAE model."
     if encoder_only:
@@ -243,8 +251,6 @@ def _create_prithvi(
 
         model.forward = forward_filter_indices
         model.out_indices = out_indices
-        model.model_bands = model_bands
-        model.pretrained_bands = pretrained_bands
 
     return model
 

--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -207,10 +207,6 @@ def _create_prithvi(
         prithvi_model_class = PrithviMAE
         checkpoint_filter_wrapper_fn = checkpoint_filter_fn_mae
 
-    if pretrained:
-        assert variant in pretrained_weights, (f"No pre-trained model found for variant {variant} "
-                                               f"(pretrained models: {pretrained_weights.keys()})")
-
     model = prithvi_model_class(**model_args)
 
     if pretrained:
@@ -224,6 +220,9 @@ def _create_prithvi(
             if loaded_keys.unexpected_keys:
                 logger.warning(f"Missing keys in ckpt_path {ckpt_path}: {loaded_keys.missing_keys}")
         else:
+            assert variant in pretrained_weights, (f"No pre-trained model found for variant {variant} "
+                                                   f"(pretrained models: {pretrained_weights.keys()})")
+
             try:
                 # Download config.json to count model downloads
                 _ = hf_hub_download(repo_id=pretrained_weights[variant]["hf_hub_id"], filename="config.json")
@@ -236,6 +235,8 @@ def _create_prithvi(
             except RuntimeError as e:
                 logger.error(f"Failed to load the pre-trained weights for {variant}.")
                 raise e
+    elif ckpt_path is not None:
+        logger.warning(f"ckpt_path is provided but pretrained is set to False, ignoring ckpt_path {ckpt_path}.")
 
     model.model_bands = model_bands
     model.pretrained_bands = pretrained_bands

--- a/terratorch/models/backbones/prithvi_vit.py
+++ b/terratorch/models/backbones/prithvi_vit.py
@@ -215,7 +215,7 @@ def _create_prithvi(
 
     if ckpt_path is not None:
         # Load model from checkpoint
-        state_dict = torch.load(ckpt_path, map_location="cpu")
+        state_dict = torch.load(ckpt_path, map_location="cpu", weights_only=True)
         state_dict = checkpoint_filter_wrapper_fn(state_dict, model, pretrained_bands, model_bands)
         model.load_state_dict(state_dict, strict=False)
     elif pretrained:
@@ -225,7 +225,7 @@ def _create_prithvi(
             # Load model from Hugging Face
             pretrained_path = hf_hub_download(repo_id=pretrained_weights[variant]["hf_hub_id"],
                                               filename=pretrained_weights[variant]["hf_hub_filename"])
-            state_dict = torch.load(pretrained_path, map_location="cpu")
+            state_dict = torch.load(pretrained_path, map_location="cpu", weights_only=True)
             state_dict = checkpoint_filter_wrapper_fn(state_dict, model, pretrained_bands, model_bands)
             model.load_state_dict(state_dict, strict=True)
         except RuntimeError as e:


### PR DESCRIPTION
- Fix prithvi for temporal tasks, i.e. the interpolated pos embeddings.
- `ckpt_path` requires `pretrained=True` and prints out warnings when keys are not matching.