### PR TITLE
Workaround to fix problem with the key `label` for classification tasks

### DIFF
--- a/examples/confs/eurosat.yaml
+++ b/examples/confs/eurosat.yaml
@@ -10,7 +10,7 @@ trainer:
   logger:
     class_path: TensorBoardLogger
     init_args:
-      save_dir: <your_path_here>/torchgeo_eurosat
+      save_dir: ./torchgeo_eurosat
       name: eurosat
   callbacks:
     - class_path: RichProgressBar
@@ -26,7 +26,7 @@ trainer:
   check_val_every_n_epoch: 1
   log_every_n_steps: 50
   enable_checkpointing: true
-  default_root_dir: <your_path_here>/torchgeo_eurosat
+  default_root_dir: ./torchgeo_eurosat
 
 data:
   class_path: terratorch.datamodules.TorchNonGeoDataModule
@@ -41,7 +41,7 @@ data:
     batch_size: 32
     num_workers: 8
   dict_kwargs:
-    root: /dccstor/geofm-pre/EuroSat
+    root: ./EuroSat
     download: True
     bands:
       - B02
@@ -57,7 +57,7 @@ model:
     model_args:
       decoder: IdentityDecoder
       backbone_pretrained: true
-      backbone: prithvi_eo_v1_300
+      backbone: prithvi_eo_v2_300
       head_dim_list:
         - 384
         - 128

--- a/terratorch/datasets/transforms.py
+++ b/terratorch/datasets/transforms.py
@@ -15,7 +15,18 @@ def albumentations_to_callable_with_dict(albumentation: list[BasicTransform] | N
     albumentation = Compose(albumentation)
 
     def fn(data):
-        return albumentation(**data)
+        # workaround to solve problems with key `label`
+        if "label" in data:
+            label = data.pop("label")
+            label_in = True
+        else:
+            label_in = False
+
+        data_transformed = albumentation(**data)
+
+        if label_in:
+            data_transformed["label"] = label
+        return data_transformed
 
     return fn
 


### PR DESCRIPTION
It seems to be an issue/limitation of albumentations, which doesn't have a key for scalar outputs, but this workaround should work for now. 