### PR TITLE
ModelCheckpoint must be defined in the config dict, not during the parsing.

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -110,7 +110,7 @@ def add_default_checkpointing_config(config):
 
     if enable_checkpointing:
         if not there_is_checkpointing:
-            print("Enabling ModelCheckpoint since the user defined enable_checkpointing=True.")
+            logger.info("Enabling ModelCheckpoint since the user defined enable_checkpointing=True.")
 
             config["ModelCheckpoint"] = StateDictAwareModelCheckpoint
             config["ModelCheckpoint.filename"] = "{epoch}"
@@ -120,7 +120,7 @@ def add_default_checkpointing_config(config):
             config["StateDictModelCheckpoint.save_weights_only"] = True
             config["StateDictModelCheckpoint.monitor"] = "val/loss"
         else:
-            print("No extra checkpoint config will be added, since the user already defined it in the callbacks.")
+            logger.info("No extra checkpoint config will be added, since the user already defined it in the callbacks.")
 
     return config 
 

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -393,22 +393,6 @@ class MyLightningCLI(LightningCLI):
         parser.add_argument("--deploy_config_file", type=bool, default=True)
         parser.add_argument("--custom_modules_path", type=str, default=None)
 
-        # parser.set_defaults({"trainer.enable_checkpointing": False})
-        """
-        parser.add_lightning_class_args(StateDictAwareModelCheckpoint, "ModelCheckpoint")
-        parser.set_defaults({"ModelCheckpoint.filename": "{epoch}", "ModelCheckpoint.monitor": "val/loss"})
-
-        parser.add_lightning_class_args(StateDictAwareModelCheckpoint, "StateDictModelCheckpoint")
-        parser.set_defaults(
-            {
-                "StateDictModelCheckpoint.filename": "{epoch}_state_dict",
-                "StateDictModelCheckpoint.save_weights_only": True,
-                "StateDictModelCheckpoint.monitor": "val/loss",
-            }
-        )
-
-        parser.link_arguments("ModelCheckpoint.dirpath", "StateDictModelCheckpoint.dirpath")
-        """
     def instantiate_classes(self) -> None:
 
         # Adding default configuration for checkpoint saving when 

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -103,17 +103,14 @@ def add_default_checkpointing_config(config):
 
     if enable_checkpointing:
         print("Enabling ModelCheckpoint since the user defined enable_checkpointing=True.")
-        config["ModelCheckpoint"] = {}
-        config["ModelCheckpoint"]["init_args"] = {}
-        config["ModelCheckpoint"]["class_path"] = StateDictAwareModelCheckpoint
-        config["ModelCheckpoint"]["init_args"]["filename"] = "{epoch}"
-        config["ModelCheckpoint"]["init_args"]["monitor"] = "val/loss"
-        config["StateDictModelCheckpoint"] = {}
-        config["StateDictModelCheckpoint"]["init_args"] = {}
-        config["StateDictModelCheckpoint"]["class_path"] = StateDictAwareModelCheckpoint
-        config["StateDictModelCheckpoint"]["init_args"]["filename"] = "{epoch}_state_dict",
-        config["StateDictModelCheckpoint"]["init_args"]["save_weights_only"] = True,
-        config["StateDictModelCheckpoint"]["init_args"]["monitor"] = "val/loss",
+
+        config["ModelCheckpoint"] = StateDictAwareModelCheckpoint
+        config["ModelCheckpoint.filename"] = "{epoch}"
+        config["ModelCheckpoint.monitor"] = "val/loss"
+        config["StateDictModelCheckpoint"] = StateDictAwareModelCheckpoint
+        config["StateDictModelCheckpoint.filename"] = "{epoch}_state_dict"
+        config["StateDictModelCheckpoint.save_weights_only"] = True
+        config["StateDictModelCheckpoint.monitor"] = "val/loss"
 
     return config 
 

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -103,15 +103,17 @@ def add_default_checkpointing_config(config):
 
     if enable_checkpointing:
         print("Enabling ModelCheckpoint since the user defined enable_checkpointing=True.")
-
-        config["ModelCheckpoint"] = StateDictAwareModelCheckpoint
-        config["ModelCheckpoint"].filename = "{epoch}"
-        config["ModelCheckpoint"].monitor = "val/loss"
-
-        config["StateDictModelCheckpoint"] = StateDictAwareModelCheckpoint
-        config["StateDictModelCheckpoint"].filename = "{epoch}_state_dict",
-        config["StateDictModelCheckpoint"].save_weights_only = True,
-        config["StateDictModelCheckpoint"].monitor = "val/loss",
+        config["ModelCheckpoint"] = {}
+        config["ModelCheckpoint"]["init_args"] = {}
+        config["ModelCheckpoint"]["class_path"] = StateDictAwareModelCheckpoint
+        config["ModelCheckpoint"]["init_args"]["filename"] = "{epoch}"
+        config["ModelCheckpoint"]["init_args"]["monitor"] = "val/loss"
+        config["StateDictModelCheckpoint"] = {}
+        config["StateDictModelCheckpoint"]["init_args"] = {}
+        config["StateDictModelCheckpoint"]["class_path"] = StateDictAwareModelCheckpoint
+        config["StateDictModelCheckpoint"]["init_args"]["filename"] = "{epoch}_state_dict",
+        config["StateDictModelCheckpoint"]["init_args"]["save_weights_only"] = True,
+        config["StateDictModelCheckpoint"]["init_args"]["monitor"] = "val/loss",
 
     return config 
 

--- a/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_300.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_300.yaml
@@ -20,7 +20,20 @@ trainer:
       init_args:
         monitor: val/loss
         patience: 100
-  max_epochs: 1
+    - class_path: StateDictAwareModelCheckpoint
+      init_args:
+        filename: "{epoch}"
+        monitor: "val/loss"
+        every_n_epochs: 2
+        verbose: true
+    - class_path: StateDictAwareModelCheckpoint
+      init_args:
+        filename: "{epoch}_state_dict"
+        save_weights_only: true
+        monitor: "val/loss"
+        every_n_epochs: 2
+        verbose: true
+  max_epochs: 4
   check_val_every_n_epoch: 1
   log_every_n_steps: 20
   enable_checkpointing: true


### PR DESCRIPTION
It should avoid the issue:
```
    raise MisconfigurationException(
lightning.fabric.utilities.exceptions.MisconfigurationException: Trainer was configured with `enable_checkpointing=False` but found `ModelCheckpoint` in callbacks list.

```