### PR TITLE
pinning albumentations==1.4.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "torch",
   "torchvision",
   "rioxarray",
-  "albumentations==1.4.5",
+  "albumentations==1.4.6",
   "albucore==0.0.16",
   "rasterio",
   "torchmetrics",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "torch",
   "torchvision",
   "rioxarray",
-  "albumentations==1.4.0",
+  "albumentations==1.4.5",
   "albucore==0.0.16",
   "rasterio",
   "torchmetrics",


### PR DESCRIPTION
@blumenstiel has observed that D4 is missing in `albumentations==1.4.0`. 