### PR TITLE
Using the TerraTorch registry for Swin

### DIFF
--- a/terratorch/models/backbones/prithvi_swin.py
+++ b/terratorch/models/backbones/prithvi_swin.py
@@ -10,12 +10,13 @@ from collections import OrderedDict
 import torch
 from timm.models import SwinTransformer
 from timm.models._builder import build_model_with_cfg
-from timm.models._registry import generate_default_cfgs, register_model
+from timm.models._registry import generate_default_cfgs
 
 from terratorch.datasets.utils import HLSBands
 from terratorch.models.backbones.select_patch_embed_weights import select_patch_embed_weights
 from terratorch.models.backbones.swin_encoder_decoder import MMSegSwinTransformer
 from terratorch.datasets.utils import generate_bands_intervals
+from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY
 
 logger = logging.getLogger(__name__)
 
@@ -261,8 +262,7 @@ def _create_swin_mmseg_transformer(
     model.prepare_features_for_image_model = prepare_features_for_image_model
     return model
 
-
-@register_model
+@TERRATORCH_BACKBONE_REGISTRY.register
 def prithvi_swin_B(
     pretrained: bool = False,  # noqa: FBT002, FBT001
     pretrained_bands: list[HLSBands] | None = None,
@@ -293,7 +293,7 @@ def prithvi_swin_B(
     return transformer
 
 
-@register_model
+@TERRATORCH_BACKBONE_REGISTRY.register
 def prithvi_swin_L(
     pretrained: bool = False,  # noqa: FBT002, FBT001
     pretrained_bands: list[HLSBands] | None = None,

--- a/terratorch/models/backbones/swin_encoder_decoder.py
+++ b/terratorch/models/backbones/swin_encoder_decoder.py
@@ -984,6 +984,9 @@ class MMSegSwinTransformer(nn.Module):
                 in_chans = downsample.out_channels
         self.stages = nn.Sequential(*stages)
         self.num_features = [int(embed_dim * 2**i) for i in range(self.num_layers)]
+
+        self.out_channels = [int(embed_dim * 2**i) for i in range(self.num_layers)]
+
         # Add a norm layer for each output
 
         self.head = ClassifierHead(

--- a/terratorch/registry/registry.py
+++ b/terratorch/registry/registry.py
@@ -3,6 +3,9 @@ from collections import OrderedDict
 from collections.abc import Callable, Mapping, Set
 from contextlib import suppress
 from reprlib import recursive_repr as _recursive_repr
+import logging
+
+logger = logging.getLogger(__name__)
 
 class BuildableRegistry(typing.Protocol):
     def __iter__(self): ...
@@ -138,7 +141,12 @@ class Registry(Set):
         """Build and return the component.
         Use prefixes ending with _ to forward to a specific source
         """
-        return self._registry[name](*constructor_args, **constructor_kwargs)
+        try:
+            return self._registry[name](*constructor_args, **constructor_kwargs)
+        except KeyError as ke:
+            for key in self._registry.keys():
+                logger.debug(f'Registered registry {key}')
+            raise ValueError(f"Class '{name}' is not registered.") from ke
 
     def __iter__(self):
         return iter(self._registry)


### PR DESCRIPTION
To use the TerraTorch registry (in replacement to timm) I added the attribute `out_channels` for the Swin architectures, but I'm not perfeclty sure about this choice. 
I belive it shoudl be merged before #472 in order to solve the issues with Swin not being found. 