### PR TITLE
Updating the tests workflows to install granitewxc and prithviwxc from PyPI.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,7 +22,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12.7"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
       - name: Clone repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,9 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -e .[test]
-          pip install git+https://github.com/NASA-IMPACT/Prithvi-WxC.git
-          pip install git+https://github.com/IBM/granite-wxc.git
+          pip install -e .[wxc,test]
       - name: List pip dependencies
         run: pip list
       - name: Test with pytest


### PR DESCRIPTION
* They are available on PyPI, so it's better to use them instead of the GitHub versions. 
* Trying to remove the limitation over Python 3.12. 