### PR TITLE
Options to directly informing kwargs for backbones and decoders

### DIFF
--- a/terratorch/models/encoder_decoder_factory.py
+++ b/terratorch/models/encoder_decoder_factory.py
@@ -75,6 +75,9 @@ class EncoderDecoderFactory(ModelFactory):
         task: str,
         backbone: str | nn.Module,
         decoder: str | nn.Module,
+        backbone_kwargs: dict | None = None,
+        decoder_kwargs: dict | None = None,
+        head_kwargs: dict | None = None,
         num_classes: int | None = None,
         necks: list[dict] | None = None,
         aux_decoders: list[AuxiliaryHead] | None = None,
@@ -98,6 +101,9 @@ class EncoderDecoderFactory(ModelFactory):
                     If an nn.Module, we expect it to expose a property `decoder.out_channels`.
                     Pixel wise tasks will be concatenated with a Conv2d for the final convolution.
                     Defaults to "FCNDecoder".
+            backbone_kwargs (dict, optional) : Arguments to be passed to instantiate the backbone.
+            decoder_kwargs (dict, optional) : Arguments to be passed to instantiate the decoder.
+            head_kwargs (dict, optional) : Arguments to be passed to the head network. 
             num_classes (int, optional): Number of classes. None for regression tasks.
             necks (list[dict]): nn.Modules to be called in succession on encoder features
                 before passing them to the decoder. Should be registered in the NECKS_REGISTRY registry.
@@ -127,7 +133,9 @@ class EncoderDecoderFactory(ModelFactory):
             msg = f"Task {task} not supported. Please choose one of {SUPPORTED_TASKS}"
             raise NotImplementedError(msg)
 
-        backbone_kwargs, kwargs = extract_prefix_keys(kwargs, "backbone_")
+        if not backbone_kwargs:
+            backbone_kwargs, kwargs = extract_prefix_keys(kwargs, "backbone_")
+
         backbone = _get_backbone(backbone, **backbone_kwargs)
 
         # If patch size is not provided in the config or by the model, it might lead to errors due to irregular images.
@@ -165,8 +173,11 @@ class EncoderDecoderFactory(ModelFactory):
         # for these, we pass the num_classes to them
         # others dont include a head
         # for those, we dont pass num_classes
-        decoder_kwargs, kwargs = extract_prefix_keys(kwargs, "decoder_")
-        head_kwargs, kwargs = extract_prefix_keys(kwargs, "head_")
+        if not decoder_kwargs:
+            decoder_kwargs, kwargs = extract_prefix_keys(kwargs, "decoder_")
+
+        if not head_kwargs:
+            head_kwargs, kwargs = extract_prefix_keys(kwargs, "head_")
 
         decoder, head_kwargs, decoder_includes_head = _get_decoder_and_head_kwargs(
             decoder, channel_list, decoder_kwargs, head_kwargs, num_classes=num_classes


### PR DESCRIPTION
* Informing the arguments adding a prefix (`backbone_`, `decoder_`, `head_`) can work for most part of the cases, but for some specific uses, as arguments called `decoder_channels`, it will produce conflicts. 
* This solution adds the options of passing the arguments inside a dictionary, which will avoid this bad interpretation. 
* When using YAML files, the input will look like:
```
decoder: SomeInterestedDecoder
decoder_kwargs:
       decoder_channels: [100, 200, 300, 400]
```
