### PR TITLE
Correct number of bands for  single band (as for segmentation) output file. 

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -85,8 +85,9 @@ def write_tiff(img_wrt, filename, metadata):
 
     # Adapting the number of bands to be compatible with the 
     # output dimensions.
-    count = img_wrt.shape[0]
-    metadata['count'] = count
+    if not is_one_band(img_wrt):
+        count = img_wrt.shape[0]
+        metadata['count'] = count
 
     with rasterio.open(filename, "w", **metadata) as dest:
         if is_one_band(img_wrt):


### PR DESCRIPTION
The `count` parameter was being modified inside `write_tiff`, making the output files with an artificial number of bands.
