### PR TITLE
makes multitemporal crop metadata filename flexible

### DIFF
--- a/terratorch/datamodules/multi_temporal_crop_classification.py
+++ b/terratorch/datamodules/multi_temporal_crop_classification.py
@@ -48,6 +48,7 @@ class MultiTemporalCropClassificationDataModule(NonGeoDataModule):
         expand_temporal_dimension: bool = True,
         reduce_zero_label: bool = True,
         use_metadata: bool = False,
+        metadata_file_name: str = "chips_df.csv",
         **kwargs: Any,
     ) -> None:
         """
@@ -89,6 +90,7 @@ class MultiTemporalCropClassificationDataModule(NonGeoDataModule):
         self.expand_temporal_dimension = expand_temporal_dimension
         self.reduce_zero_label = reduce_zero_label
         self.use_metadata = use_metadata
+        self.metadata_file_name = metadata_file_name
 
     def setup(self, stage: str) -> None:
         """Set up datasets.
@@ -107,6 +109,7 @@ class MultiTemporalCropClassificationDataModule(NonGeoDataModule):
                 expand_temporal_dimension = self.expand_temporal_dimension,
                 reduce_zero_label = self.reduce_zero_label,
                 use_metadata=self.use_metadata,
+                metadata_file_name=self.metadata_file_name,
             )
         if stage in ["fit", "validate"]:
             self.val_dataset = self.dataset_class(
@@ -119,6 +122,7 @@ class MultiTemporalCropClassificationDataModule(NonGeoDataModule):
                 expand_temporal_dimension = self.expand_temporal_dimension,
                 reduce_zero_label = self.reduce_zero_label,
                 use_metadata=self.use_metadata,
+                metadata_file_name=self.metadata_file_name,
             )
         if stage in ["test"]:
             self.test_dataset = self.dataset_class(
@@ -131,6 +135,7 @@ class MultiTemporalCropClassificationDataModule(NonGeoDataModule):
                 expand_temporal_dimension = self.expand_temporal_dimension,
                 reduce_zero_label = self.reduce_zero_label,
                 use_metadata=self.use_metadata,
+                metadata_file_name=self.metadata_file_name,
             )
         if stage in ["predict"]:
             self.predict_dataset = self.dataset_class(
@@ -143,6 +148,7 @@ class MultiTemporalCropClassificationDataModule(NonGeoDataModule):
                 expand_temporal_dimension = self.expand_temporal_dimension,
                 reduce_zero_label = self.reduce_zero_label,
                 use_metadata=self.use_metadata,
+                metadata_file_name=self.metadata_file_name,
             )
 
     def _dataloader_factory(self, split: str) -> DataLoader[dict[str, Tensor]]:

--- a/terratorch/datasets/multi_temporal_crop_classification.py
+++ b/terratorch/datasets/multi_temporal_crop_classification.py
@@ -56,7 +56,6 @@ class MultiTemporalCropClassification(NonGeoDataset):
     num_classes = 13
     time_steps = 3
     splits = {"train": "training", "val": "validation"}  # Only train and val splits available
-    metadata_file_name = "chips_df.csv"
     col_name = "chip_id"
     date_columns = ["first_img_date", "middle_img_date", "last_img_date"]
 
@@ -71,6 +70,7 @@ class MultiTemporalCropClassification(NonGeoDataset):
         expand_temporal_dimension: bool = True,
         reduce_zero_label: bool = True,
         use_metadata: bool = False,
+        metadata_file_name: str = "chips_df.csv",
     ) -> None:
         """Constructor
 
@@ -130,6 +130,7 @@ class MultiTemporalCropClassification(NonGeoDataset):
         self.expand_temporal_dimension = expand_temporal_dimension
         self.use_metadata = use_metadata
         self.metadata = None
+        self.metadata_file_name = metadata_file_name
         if self.use_metadata:
             metadata_file = self.data_root / self.metadata_file_name
             self.metadata = pd.read_csv(metadata_file)
@@ -156,7 +157,7 @@ class MultiTemporalCropClassification(NonGeoDataset):
         temporal_coords = []
         for col in self.date_columns:
             date_str = row[col]
-            date = pd.to_datetime(date_str, format="%Y-%m-%d")
+            date = pd.to_datetime(date_str, infer_datetime_format=True)
             temporal_coords.append([date.year, date.dayofyear - 1])
 
         return torch.tensor(temporal_coords, dtype=torch.float32)


### PR DESCRIPTION
This commit introduces two improvements to the MultiTemporalCropClassification dataset and its corresponding datamodule:

1. The metadata file name is now configurable through a class parameter (`metadata_file_name`), allowing users to specify alternative metadata files instead of being restricted to a fixed name.

2. The dataset now supports flexible datetime strings with timestamps (e.g., "2022-05-13T17:01:11.858Z") when parsing metadata dates. This makes it compatible with extended metadata formats that include time information.

Changes are localized to `datasets/multi_temporal_crop_classification.py` and `datamodules/multi_temporal_crop_classification.py`, without affecting other functionality or naming conventions.
