### PR TITLE
Explicitly save only the best model

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -358,6 +358,7 @@ class StateDictAwareModelCheckpoint(ModelCheckpoint):
         verbose: bool = False,
         save_last: bool | None = None,
         save_top_k: int = 1,
+        save_best_only: bool = False,
         mode: str = "min",
         save_weights_only: bool = False,
         auto_insert_metric_name: bool = True,
@@ -367,6 +368,9 @@ class StateDictAwareModelCheckpoint(ModelCheckpoint):
         save_on_train_epoch_end: bool | None = None,
         enable_version_counter: bool = True,
     ):
+        if save_best_only:
+            save_top_k = 1
+
         super().__init__(
             dirpath,
             filename,

--- a/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_300.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_300.yaml
@@ -26,6 +26,7 @@ trainer:
         monitor: "val/loss"
         every_n_epochs: 2
         verbose: true
+        save_top_k: 1
     - class_path: StateDictAwareModelCheckpoint
       init_args:
         filename: "{epoch}_state_dict"
@@ -33,7 +34,8 @@ trainer:
         monitor: "val/loss"
         every_n_epochs: 2
         verbose: true
-  max_epochs: 4
+        save_top_k: 1
+  max_epochs: 10
   check_val_every_n_epoch: 1
   log_every_n_steps: 20
   enable_checkpointing: true


### PR DESCRIPTION
It sets `save_top_k` to 1 when the variable save_best_only is passed to `StateDictAwareModelCheckpoint`. In this way, just the best model is kept or overwritten when a new best is found. 