### PR TITLE
Header for indicating source code originally pulled from torchgeo

### DIFF
--- a/terratorch/datasets/biomassters.py
+++ b/terratorch/datasets/biomassters.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 import os
 import random
 from collections.abc import Sequence

--- a/terratorch/datasets/generic_multimodal_dataset.py
+++ b/terratorch/datasets/generic_multimodal_dataset.py
@@ -1,4 +1,5 @@
-# Copyright contributors to the Terratorch project
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 """Module containing generic dataset classes"""
 

--- a/terratorch/datasets/generic_pixel_wise_dataset.py
+++ b/terratorch/datasets/generic_pixel_wise_dataset.py
@@ -1,4 +1,5 @@
-# Copyright contributors to the Terratorch project
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 """Module containing generic dataset classes"""
 


### PR DESCRIPTION
This header will indicate the parts of the codebase which were copied/adapted from torchgeo. 
A further investigation is required to identify others regions in which a similar behaviour has happened. 