### PR TITLE
Add test for LoRA and update PEFT requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,8 @@ dev = [
 test = [
   "pytest",
   "pytest-coverage",
-  "coverage-badge"
+  "coverage-badge",
+  "peft>=0.15.0"
 ]
 
 mmseg = [
@@ -92,7 +93,7 @@ visualize = [
 ]
 
 peft = [
-  "peft"
+  "peft>=0.15.0"
 ]
 
 [project.urls]

--- a/terratorch/models/peft_utils.py
+++ b/terratorch/models/peft_utils.py
@@ -6,10 +6,11 @@ import torch
 from torch import nn
 
 try:
-    from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING, get_peft_model
+    from peft.mapping import PEFT_TYPE_TO_CONFIG_MAPPING
+    from peft.mapping_func import get_peft_model
 
     _has_peft = True
-except ImportError:
+except ModuleNotFoundError:
     _has_peft = False
 
 TESTED_PEFT_METHODS = ["LORA"]

--- a/tests/test_encoder_decoder_model_factory.py
+++ b/tests/test_encoder_decoder_model_factory.py
@@ -398,7 +398,7 @@ def test_create_model_with_lora(backbone, task, expected, decoder, model_factory
 
     if task == "segmentation":
         model_args["num_classes"] = NUM_CLASSES
-    if decoder in ["UperNetDecoder", "UNetDecoder"] and backbone.startswith("prithvi_eo"):
+    if decoder in ["UperNetDecoder", "UNetDecoder"]:
         model_args["necks"] = VIT_UPERNET_NECK
     if decoder == "UNetDecoder":
         model_args["decoder_channels"] = [256, 128, 64, 32]


### PR DESCRIPTION
With the release of PEFT 0.15.0 they moved some methods around and our imports crashed, see [this](https://github.com/huggingface/peft/pull/2282/files). This PR should fix it, it also adds a test to be able to notice in future updates and to test that the LoRA method works well for prithvi and clay.