### PR TITLE
Special case when callbacks is empty and checkpointing is enabled. 

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -102,13 +102,17 @@ def add_default_checkpointing_config(config):
     if subcommand is not None:
         enable_checkpointing = config[subcommand + ".trainer.enable_checkpointing"]
         callbacks = config[subcommand + ".trainer.callbacks"]
-        check_callbacks = [op for op in callbacks if "ModelCheckpoint" in op.class_path]
-    
-        if len(check_callbacks) > 0:
-            there_is_checkpointing = True
+
+        if callbacks:
+            check_callbacks = [op for op in callbacks if "ModelCheckpoint" in op.class_path]
+        
+            if len(check_callbacks) > 0:
+                there_is_checkpointing = True
+            else:
+                there_is_checkpointing = False
         else:
             there_is_checkpointing = False
-    
+
         if enable_checkpointing:
             if not there_is_checkpointing:
                 logger.info("Enabling ModelCheckpoint since the user defined enable_checkpointing=True.")


### PR DESCRIPTION
Sometimes the list of callbacks is empy t, but the user still want to have automatic checkpointing, 