### PR TITLE
An attempt of reducing the cost of testing by simplifying the list of tests. 

### DIFF
--- a/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_300.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_300.yaml
@@ -35,7 +35,7 @@ trainer:
         every_n_epochs: 2
         verbose: true
         save_top_k: 1
-  max_epochs: 10
+  max_epochs: 1
   check_val_every_n_epoch: 1
   log_every_n_steps: 20
   enable_checkpointing: true

--- a/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_600_segmentation_tiled.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_eo_v2_600_segmentation_tiled.yaml
@@ -20,7 +20,7 @@ trainer:
       init_args:
         monitor: val/loss
         patience: 100
-  max_epochs: 5
+  max_epochs: 1
   check_val_every_n_epoch: 1
   log_every_n_steps: 20
   enable_checkpointing: true

--- a/tests/resources/configs/manufactured-finetune_prithvi_swin_B_segmentation.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_swin_B_segmentation.yaml
@@ -20,7 +20,7 @@ trainer:
       init_args:
         monitor: val/loss
         patience: 100
-  max_epochs: 5
+  max_epochs: 1
   check_val_every_n_epoch: 1
   log_every_n_steps: 20
   enable_checkpointing: true

--- a/tests/test_finetune.py
+++ b/tests/test_finetune.py
@@ -23,7 +23,9 @@ def setup_and_cleanup(model_name):
     if os.path.isdir(os.path.join("tests", "all_ecos_random")):
         shutil.rmtree(os.path.join("tests", "all_ecos_random"))
 
-@pytest.mark.parametrize("model_name", ["prithvi_eo_v1_100", "prithvi_eo_v2_300", "prithvi_swin_B", "prithvi_swin_L", "prithvi_eo_v2_600"])
+# The backbones `prithvi_eo_v2_300` and `prithvi_swin_B` are already used in
+# others tests and don't need be tested here again
+@pytest.mark.parametrize("model_name", ["prithvi_eo_v1_100", "prithvi_swin_L", "prithvi_eo_v2_600"])
 @pytest.mark.parametrize("case", ["fit", "test", "validate", "compute_statistics"])
 def test_finetune_multiple_backbones(model_name, case):
     command_list = [case, "-c", f"tests/resources/configs/manufactured-finetune_{model_name}.yaml"]

--- a/tests/test_prithvi_tasks.py
+++ b/tests/test_prithvi_tasks.py
@@ -30,9 +30,35 @@ def model_input() -> torch.Tensor:
 
 @pytest.mark.parametrize("backbone", ["prithvi_eo_v1_100", "prithvi_eo_v2_300", "prithvi_swin_B"])
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])
-@pytest.mark.parametrize("loss", ["ce", "jaccard", "focal", "dice"])
+@pytest.mark.parametrize("loss", ["ce"])
 @pytest.mark.parametrize("lr_overrides", [{"encoder": 0.01}, None])
-def test_create_segmentation_task(backbone, decoder, loss, model_factory: str, lr_overrides):
+def test_create_segmentation_task_encoder_decoder(backbone, decoder, loss, model_factory: str, lr_overrides):
+    model_args = {
+        "backbone": backbone,
+        "decoder": decoder,
+        "backbone_bands": PRETRAINED_BANDS,
+        "backbone_pretrained": False,
+        "num_classes": NUM_CLASSES,
+    }
+
+    if decoder in ["UperNetDecoder", "UNetDecoder"] and backbone.startswith("prithvi_eo"):
+        model_args["necks"] = VIT_UPERNET_NECK
+    if decoder == "UNetDecoder":
+        model_args["decoder_channels"] = [256, 128, 64, 32]
+    SemanticSegmentationTask(
+        model_args,
+        model_factory,
+        loss=loss,
+        lr_overrides=lr_overrides,
+    )
+
+    gc.collect()
+
+@pytest.mark.parametrize("backbone", ["prithvi_eo_v2_300"])
+@pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])
+@pytest.mark.parametrize("loss", ["ce", "jaccard", "focal", "dice"])
+@pytest.mark.parametrize("lr_overrides", [None])
+def test_create_segmentation_task_decoder_to_optim(backbone, decoder, loss, model_factory: str, lr_overrides):
     model_args = {
         "backbone": backbone,
         "decoder": decoder,
@@ -57,9 +83,35 @@ def test_create_segmentation_task(backbone, decoder, loss, model_factory: str, l
 
 @pytest.mark.parametrize("backbone", ["prithvi_eo_v1_100", "prithvi_eo_v2_300", "prithvi_swin_B"])
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])
-@pytest.mark.parametrize("loss", ["mae", "rmse", "huber"])
+@pytest.mark.parametrize("loss", ["mae"])
 @pytest.mark.parametrize("lr_overrides", [{"encoder": 0.01}, None])
-def test_create_regression_task(backbone, decoder, loss, model_factory: str, lr_overrides):
+def test_create_regression_task_encoder_decoder(backbone, decoder, loss, model_factory: str, lr_overrides):
+    model_args = {
+        "backbone": backbone,
+        "decoder": decoder,
+        "backbone_bands": PRETRAINED_BANDS,
+        "backbone_pretrained": False,
+    }
+
+    if decoder in ["UperNetDecoder", "UNetDecoder"] and backbone.startswith("prithvi_eo"):
+        model_args["necks"] = VIT_UPERNET_NECK
+    if decoder == "UNetDecoder":
+        model_args["decoder_channels"] = [256, 128, 64, 32]
+
+    PixelwiseRegressionTask(
+        model_args,
+        model_factory,
+        loss=loss,
+        lr_overrides=lr_overrides,
+    )
+
+    gc.collect()
+
+@pytest.mark.parametrize("backbone", ["prithvi_eo_v2_300"])
+@pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])
+@pytest.mark.parametrize("loss", ["mae", "rmse", "huber"])
+@pytest.mark.parametrize("lr_overrides", [None])
+def test_create_regression_task_decoder_to_optim(backbone, decoder, loss, model_factory: str, lr_overrides):
     model_args = {
         "backbone": backbone,
         "decoder": decoder,
@@ -84,9 +136,9 @@ def test_create_regression_task(backbone, decoder, loss, model_factory: str, lr_
 
 @pytest.mark.parametrize("backbone", ["prithvi_eo_v1_100", "prithvi_eo_v2_300", "prithvi_swin_B"])
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])
-@pytest.mark.parametrize("loss", ["ce", "bce", "jaccard", "focal"])
+@pytest.mark.parametrize("loss", ["ce"])
 @pytest.mark.parametrize("lr_overrides", [{"encoder": 0.01}, None])
-def test_create_classification_task(backbone, decoder, loss, model_factory: str, lr_overrides):
+def test_create_classification_task_encoder_decoder(backbone, decoder, loss, model_factory: str, lr_overrides):
     model_args = {
         "backbone": backbone,
         "decoder": decoder,
@@ -108,3 +160,32 @@ def test_create_classification_task(backbone, decoder, loss, model_factory: str,
     )
 
     gc.collect()
+
+@pytest.mark.parametrize("backbone", ["prithvi_eo_v2_300"])
+@pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])
+@pytest.mark.parametrize("loss", ["ce", "bce", "jaccard", "focal"])
+@pytest.mark.parametrize("lr_overrides", [None])
+def test_create_classification_task_decoder_to_optim(backbone, decoder, loss, model_factory: str, lr_overrides):
+    model_args = {
+        "backbone": backbone,
+        "decoder": decoder,
+        "backbone_bands": PRETRAINED_BANDS,
+        "backbone_pretrained": False,
+        "num_classes": NUM_CLASSES,
+    }
+
+    if decoder in ["UperNetDecoder", "UNetDecoder"] and backbone.startswith("prithvi_eo"):
+        model_args["necks"] = VIT_UPERNET_NECK
+    if decoder == "UNetDecoder":
+        model_args["decoder_channels"] = [256, 128, 64, 32]
+
+    ClassificationTask(
+        model_args,
+        model_factory,
+        loss=loss,
+        lr_overrides=lr_overrides,
+    )
+
+    gc.collect()
+
+

--- a/tests/test_prithvi_tasks.py
+++ b/tests/test_prithvi_tasks.py
@@ -27,6 +27,13 @@ def model_factory() -> str:
 def model_input() -> torch.Tensor:
     return torch.ones((1, NUM_CHANNELS, 224, 224))
 
+# In tthe following tests, we avoid the "dense" tests by dividing the tasks in
+# two parts.
+
+# First we focus on the combinations between backbones and decoders. As the
+# decoders outputs are roughly the same, we don't need to repeat the tests for
+# losses and lr for all the backbones. After it, we combine multiple decoders
+# and different losses and lr levels using the same backbone. 
 
 @pytest.mark.parametrize("backbone", ["prithvi_eo_v1_100", "prithvi_eo_v2_300", "prithvi_swin_B"])
 @pytest.mark.parametrize("decoder", ["FCNDecoder", "UperNetDecoder", "IdentityDecoder", "UNetDecoder"])


### PR DESCRIPTION
* Eliminating redundant tests. 
* Avoiding to test again already excessively tested backbones (as `prithvi_swin_B`). 
The pipeline takes less 6min40s and the coverage is the same. 

```
================================ tests coverage ================================
_______________ coverage: platform linux, python 3.12.9-final-0 ________________

Name                                                           Stmts   Miss Branch BrPart  Cover   Missing
----------------------------------------------------------------------------------------------------------
terratorch/__init__.py                                             3      0      0      0   100%
terratorch/__main__.py                                            89     89     16      0     0%   5-142
terratorch/cli_tools.py                                          328    141    110     26    50%   71, 75-78, 82, 89-99, 103->134, 112, 117-118, 120->134, 132, 138-152, 159-175, 193-233, 240-255, 280->287, 284-285, 317, 319->352, 322-323, 329-339, 341->352, 347->352, 352->369, 353->369, 375->exit, 400, 452, 455, 458, 468, 496-501, 543-562, 579-598, 606-610, 622-628, 639-644, 661->663, 666-667, 680->exit
terratorch/datamodules/__init__.py                                41      4      2      1    88%   35-38, 98->exit
terratorch/datamodules/biomassters.py                             57      3     14      2    93%   126-127, 142
terratorch/datamodules/burn_intensity.py                          33      0      8      0   100%
terratorch/datamodules/carbonflux.py                              35      0      8      0   100%
terratorch/datamodules/era5.py                                    58     39      8      0    29%   24-44, 79-99, 109, 129-134, 166-172, 175, 178-189, 197, 208, 218
terratorch/datamodules/fire_scars.py                              65     19     14      0    68%   166-171, 174-196
terratorch/datamodules/forestnet.py                               35      0      8      0   100%
terratorch/datamodules/generic_multimodal_data_module.py         207     88     84     14    51%   28-38, 52-57, 68-69, 81-115, 123-126, 133-154, 319-327, 336, 338, 375, 382, 386, 393, 397, 405, 416-419, 500-518, 536->540, 542
terratorch/datamodules/generic_pixel_wise_data_module.py         137      4     22      3    96%   59-60, 65-66, 571->575
terratorch/datamodules/generic_scalar_label_data_module.py        75     11     14      1    82%   38-49, 251->255
terratorch/datamodules/geobench_data_module.py                    30      0      8      0   100%
terratorch/datamodules/landslide4sense.py                         31      0      8      0   100%
terratorch/datamodules/m_SA_crop_type.py                          11      0      0      0   100%
terratorch/datamodules/m_bigearthnet.py                           11      0      0      0   100%
terratorch/datamodules/m_brick_kiln.py                            11      0      0      0   100%
terratorch/datamodules/m_cashew_plantation.py                     11      0      0      0   100%
terratorch/datamodules/m_chesapeake_landcover.py                  11      0      0      0   100%
terratorch/datamodules/m_eurosat.py                               11      0      0      0   100%
terratorch/datamodules/m_forestnet.py                             11      0      0      0   100%
terratorch/datamodules/m_neontree.py                              11      0      0      0   100%
terratorch/datamodules/m_nz_cattle.py                             11      0      0      0   100%
terratorch/datamodules/m_pv4ger.py                                11      0      0      0   100%
terratorch/datamodules/m_pv4ger_seg.py                            11      0      0      0   100%
terratorch/datamodules/m_so2sat.py                                11      0      0      0   100%
terratorch/datamodules/merra2_downscale.py                        25     12      8      0    39%   28-43, 46, 50-67
terratorch/datamodules/multi_temporal_crop_classification.py      43      0      8      0   100%
terratorch/datamodules/open_sentinel_map.py                       27     19      8      0    23%   48-63, 71-105
terratorch/datamodules/openearthmap.py                            31      0      8      0   100%
terratorch/datamodules/pastis.py                                  25      0      8      0   100%
terratorch/datamodules/sen1floods11.py                            42      0      8      0   100%
terratorch/datamodules/sen4agrinet.py                             29     21      8      0    22%   52-69, 77-117
terratorch/datamodules/sen4map.py                                 88     16     30      9    72%   91->exit, 92->exit, 93->exit, 97-104, 111, 114-115, 123-125, 131->exit, 146-147
terratorch/datamodules/torchgeo_data_module.py                    72     36      8      0    45%   39-44, 74-81, 85, 89, 92, 95, 98, 101, 104, 134-141, 145, 149, 153, 157, 160, 163, 166, 169, 172, 175
terratorch/datamodules/utils.py                                   30     13      6      1    50%   22-23, 32-47
terratorch/datasets/__init__.py                                   32      0      0      0   100%
terratorch/datasets/biomassters.py                               258    139     86     19    41%   141-142, 190, 205, 209-213, 216, 236, 259-287, 290-297, 299-306, 308-309, 315-320, 334, 338, 354-357, 369->374, 371, 382, 385, 388, 392-399, 418-510
terratorch/datasets/burn_intensity.py                            144     23     26      9    81%   74-75, 132-145, 156, 169->172, 174, 180->182, 197, 201-202, 229-233, 247
terratorch/datasets/carbonflux.py                                135     52     22      7    59%   71-72, 114-115, 126-128, 135->137, 141-160, 164-176, 185-186, 201->204, 209-210, 224-247
terratorch/datasets/fire_scars.py                                134     26     18      8    78%   70-71, 95-104, 107-116, 123-124, 138->140, 143-144, 150->152, 168-169, 178-179, 202-203
terratorch/datasets/forestnet.py                                 143     31     30     11    75%   67-68, 86-88, 98-107, 110-119, 135->138, 139-141, 157, 169->167, 177->181, 182, 201-202, 208->210, 223
terratorch/datasets/generic_multimodal_dataset.py                355    182    160     42    46%   32-39, 49, 55-58, 161, 167->170, 185-186, 190-195, 203->207, 212, 215, 227, 230-233, 237->253, 242, 245-248, 260-261, 264->256, 268->264, 273-276, 277->300, 281, 283->296, 287->283, 292-295, 298, 300->253, 307, 312-317, 324-334, 339, 344-346, 361-362, 375, 380, 387, 390, 395, 398, 400->403, 408, 417, 419-421, 423, 563-581, 592-627, 710-712, 737-739, 754-772, 781-805, 894-922, 926-927, 943, 972-996
terratorch/datasets/generic_pixel_wise_dataset.py                181     12     50     20    86%   101-102, 125-126, 131-132, 156, 169, 170->172, 284, 285->287, 293->296, 297->302, 299->302, 333->337, 347, 446, 447->449, 455->458, 459->464, 461->464, 491->495, 496
terratorch/datasets/generic_scalar_label_dataset.py               95     32     24      7    59%   83-84, 86-97, 114-115, 119-123, 142, 144, 148->151, 160-174, 177-179, 251
terratorch/datasets/hls.py                                        20      1      0      0    95%   75
terratorch/datasets/landslide4sense.py                            86     12     14      7    81%   61-62, 95->97, 105-106, 110->113, 139-142, 145-149, 152
terratorch/datasets/m_SA_crop_type.py                             87     10     14      6    84%   68-69, 85-86, 108->110, 127-128, 133->136, 160-163
terratorch/datasets/m_bigearthnet.py                              79      6     12      5    88%   68-69, 91-92, 117->120, 135-136, 141->144
terratorch/datasets/m_brick_kiln.py                               75      6     12      5    87%   70-71, 87-88, 112->115, 131-132, 137->140
terratorch/datasets/m_cashew_plantation.py                       106     10     22      6    88%   72-73, 91-92, 132->134, 152-153, 158->161, 185-188
terratorch/datasets/m_chesapeake_landcover.py                     87     10     14      6    84%   54-55, 71-72, 94->96, 112-113, 118->121, 145-148
terratorch/datasets/m_eurosat.py                                  79      6     12      5    88%   68-69, 91-92, 117->120, 137-138, 143->146
terratorch/datasets/m_forestnet.py                                91     17     14      6    78%   66-67, 85-86, 110->113, 116-120, 133-136, 139-142, 156-157, 162->165
terratorch/datasets/m_neontree.py                                 87     10     14      6    84%   54-55, 71-72, 94->96, 112-113, 117->120, 144-147
terratorch/datasets/m_nz_cattle.py                               106     17     18      7    79%   58-59, 77-78, 106->108, 111-113, 119-123, 144-145, 150->153, 177-180
terratorch/datasets/m_pv4ger.py                                   83      6     14      5    89%   58-59, 77-78, 102->105, 131-132, 137->140
terratorch/datasets/m_pv4ger_seg.py                               97     10     16      6    86%   57-58, 76-77, 100->102, 129-130, 135->138, 162-165
terratorch/datasets/m_so2sat.py                                   76      6     12      5    88%   75-76, 92-93, 117->120, 137-138, 143->146
terratorch/datasets/multi_temporal_crop_classification.py        154      9     34      8    91%   96-97, 184->189, 190->192, 203->205, 205->207, 235-236, 251, 266-269
terratorch/datasets/open_sentinel_map.py                         151    127     50      0    12%   54-96, 99-100, 103-108, 111, 114-136, 144-159, 162-230
terratorch/datasets/openearthmap.py                               70     10      4      2    84%   58-59, 86, 126-133, 139
terratorch/datasets/pastis.py                                    161     69     60     13    53%   79-80, 84-85, 117->120, 135->140, 160, 181->185, 186, 189, 200-223, 238, 241, 249, 258-280, 289-318
terratorch/datasets/sen1floods11.py                              131      9     22      7    90%   79-80, 132, 164->166, 176->178, 194-195, 204-205, 228-229
terratorch/datasets/sen4agrinet.py                               148    125     42      0    12%   67-88, 91, 94-127, 131-193, 196-218, 221-250, 253-254
terratorch/datasets/sen4map.py                                   126     26     16      7    75%   123-127, 132, 136, 142, 163, 225, 227, 237-240, 249-265
terratorch/datasets/transforms.py                                131     79     34      3    33%   14-21, 24-27, 33-34, 38-46, 49, 66-67, 72, 96-97, 102-104, 112, 128-129, 132-137, 140, 170-187, 190-199, 202, 224-226, 229, 232, 249-250, 253, 256, 260-263, 289-292, 295-310
terratorch/datasets/utils.py                                     150     24     32      7    81%   56-59, 72-75, 110-112, 123, 125->127, 141->143, 144, 156, 165-171, 175-181, 188
terratorch/datasets/wsf.py                                        32     11      4      0    58%   58, 75-89
terratorch/io/file.py                                             34     19     10      2    43%   11-24, 29-48, 55->exit, 59-62
terratorch/models/__init__.py                                     15      3      0      0    80%   17-19
terratorch/models/backbones/__init__.py                           10      0      0      0   100%
terratorch/models/backbones/clay_v1/__init__.py                    3      0      0      0   100%
terratorch/models/backbones/clay_v1/embedder.py                   68     15     12      2    71%   66, 70-89, 116-125, 154->162
terratorch/models/backbones/clay_v1/modules.py                   204     43     22      5    77%   64-66, 136-164, 190-230, 238-279, 472-482, 490->492, 504->501, 531
terratorch/models/backbones/clay_v1/utils.py                      27      8      0      0    70%   5-13
terratorch/models/backbones/dofa_vit.py                          104     38     32      4    56%   98-104, 108-114, 120->122, 128-134, 140-164, 171-177, 184
terratorch/models/backbones/mmearth_convnextv2.py                122    122     22      0     0%   4-251
terratorch/models/backbones/multimae/criterion.py                 99     82     16      0    15%   33-37, 41-65, 76-80, 83-87, 90-94, 98-130, 141-145, 148-152, 155-159, 163-195
terratorch/models/backbones/multimae/input_adapters.py            92     74     14      0    17%   54-71, 80-100, 112, 121-142, 177-196, 205-245, 254, 263-289
terratorch/models/backbones/multimae/multimae.py                 204    179     78      0     9%   71-143, 146-152, 155, 159-173, 185-189, 208-247, 262-279, 282-300, 329-418, 443-467, 480-488
terratorch/models/backbones/multimae/multimae_utils.py           143    114      4      0    20%   26, 34-49, 55-87, 108, 119-128, 135-136, 139, 142, 154-160, 163-169, 181-189, 192-207, 212-222, 225-247, 264-276, 284-286, 302-323, 331-336
terratorch/models/backbones/multimae/output_adapter_utils.py     102     85     16      0    14%   34-49, 52-64, 75-107, 117-130, 134-192, 211-236, 243-258, 262, 281-286, 296-303
terratorch/models/backbones/multimae/output_adapters.py          306    266     64      0    11%   81-142, 151-154, 158, 164-181, 184-234, 251-282, 303-311, 320-327, 330-336, 339, 342-343, 349-356, 394-415, 424-428, 431-437, 441-448, 451-478, 506-520, 529-533, 536-542, 546-553, 556-573, 603-648, 657-710, 719-726, 729-759
terratorch/models/backbones/multimae_register.py                 144    115     54      0    15%   22, 119, 130-158, 163, 177-214, 223-248, 253-254, 257-273, 284-306, 319-349, 361-390
terratorch/models/backbones/prithvi_mae.py                       331    168     68     10    47%   67->69, 77, 100-115, 122->exit, 151-153, 200, 204->206, 212-221, 230-242, 247-256, 262-271, 314-315, 317, 359-379, 398-431, 452-454, 456-457, 508-541, 545-552, 556-564, 575-613, 639-672, 685-692, 707-717, 733-742, 751-759, 767
terratorch/models/backbones/prithvi_swin.py                      161    100     74      4    30%   41-90, 95-98, 104-108, 112-114, 118-192, 203, 206-207, 224, 273->275, 304->306
terratorch/models/backbones/prithvi_vit.py                       158     55     52      9    58%   101, 109, 111, 116, 130-158, 180-187, 207-208, 215-222, 236-238, 240, 246->257, 267, 307, 317, 328-331, 340-343, 353, 363, 373, 382, 392
terratorch/models/backbones/scalemae.py                          134     28     20      3    73%   102->112, 173->177, 203-215, 248-258, 261-285, 293-295, 309
terratorch/models/backbones/select_patch_embed_weights.py         79     21     42      9    70%   15, 27-28, 34, 40-54, 68->77, 69->68, 73, 80-83, 104->146, 113, 144
terratorch/models/backbones/swin_encoder_decoder.py              402     76    106     22    75%   89, 91, 137, 150, 160, 182-183, 189->193, 248-249, 274-277, 324, 338, 354, 357-372, 390->393, 396->398, 462, 545-546, 564-565, 745, 801-804, 919-924, 933-934, 1003-1004, 1007-1023, 1027-1032, 1036-1040, 1044, 1057, 1060-1061
terratorch/models/backbones/torchgeo_resnet.py                   347     59    104     41    75%   109, 117, 126, 135, 144, 153, 162, 171, 180, 189, 198, 207, 216, 226, 235, 243, 251, 259, 267, 275, 283, 291, 299, 307, 315-317, 325-327, 335->337, 345-347, 355-357, 365, 373, 381, 389, 397, 405, 414, 422, 430, 438, 447-467, 469->476
terratorch/models/backbones/torchgeo_swin_satlas.py              168     78     46      3    47%   119-123, 127-131, 135-139, 143-147, 151-155, 159-163, 169->171, 175-179, 183-187, 191-195, 199-203, 207-211, 215-219, 223-227, 235-255, 257->265
terratorch/models/backbones/torchgeo_vit.py                      129     37     32     11    64%   69-71, 86, 95, 103, 111, 119, 127, 135, 143, 151, 159, 167, 174-209
terratorch/models/backbones/unet.py                               74     56     26      0    18%   98-197, 204-214, 219-224, 227-232
terratorch/models/backbones/utils.py                              74     54     12      0    23%   28-39, 94-116, 128, 136-139, 183-203, 208-212, 242-263, 268-272, 320-336, 341-345
terratorch/models/clay_model_factory.py                          102     38     32     10    60%   35-39, 42, 46, 49-53, 108, 117-118, 122-123, 136-144, 148->154, 150->154, 173-193, 228->exit, 242, 247-251
terratorch/models/decoders/__init__.py                             9      0      0      0   100%
terratorch/models/decoders/aspp_head.py                          107     16     22      8    80%   95->98, 98->101, 101->104, 136->exit, 162-170, 172, 206-208, 246->exit, 253->255, 288-300, 305-308, 313-316
terratorch/models/decoders/fcn_decoder.py                         41      2      4      1    93%   60-61
terratorch/models/decoders/identity_decoder.py                    13      0      0      0   100%
terratorch/models/decoders/linear_decoder.py                      16      1      0      0    94%   40
terratorch/models/decoders/mlp_decoder.py                         20     13      0      0    35%   23-30, 34-39
terratorch/models/decoders/satmae_head.py                         86     73      8      0    14%   17-47, 58-64, 70-95, 103-132, 143-149, 154-182
terratorch/models/decoders/unet_decoder.py                        15      0      0      0   100%
terratorch/models/decoders/upernet_decoder.py                     77      0     16      0   100%
terratorch/models/decoders/utils.py                               31      8     12      4    63%   19, 27-28, 49->63, 51-57
terratorch/models/encoder_decoder_factory.py                     102     17     46      9    80%   28, 41-46, 62-63, 77, 142-143, 145->148, 163-167, 173-175, 185->188, 188->191, 267->exit
terratorch/models/generic_unet_model_factory.py                   95     75     22      0    17%   20-21, 27-42, 69-109, 115-124, 127, 131, 136-150, 153, 156, 160-170
terratorch/models/heads/__init__.py                                4      0      0      0   100%
terratorch/models/heads/classification_head.py                    23      7      4      2    67%   35-40, 52-53
terratorch/models/heads/regression_head.py                        41      6      6      1    85%   66-78
terratorch/models/heads/segmentation_head.py                      16      5      2      1    67%   27-36
terratorch/models/model.py                                        33      3      2      1    89%   21, 25, 29, 33->exit
terratorch/models/necks.py                                       134     28     16      3    75%   28->exit, 78-80, 83-88, 91, 103-104, 107-115, 118, 163, 190-191, 194-196, 199, 211-212
terratorch/models/peft_utils.py                                   79     11     18      6    82%   13-14, 41-42, 49-53, 56->58, 66-67, 108-109, 113
terratorch/models/pincers/unet_pincer.py                          80     65     20      0    15%   9-37, 40-47, 52-77, 80-90, 107-123, 126-154, 157-158, 163-168, 171
terratorch/models/pincers/wxc_downscaling_pincer.py               18     10      4      0    36%   11-48
terratorch/models/pincers/wxc_embedding_network.py                22     15      8      0    23%   11-49
terratorch/models/pincers/wxc_upscaler.py                          5      2      0      0    60%   6-14
terratorch/models/pixel_wise_model.py                             86     11     30      3    84%   83, 86, 100-106, 147-148, 152-153
terratorch/models/prithvi_model_factory.py                        30      4      8      3    82%   84-88, 91->96, 93-94
terratorch/models/satmae_model_factory.py                        151    119     52      0    16%   31-34, 39-50, 55-72, 75, 79, 83-85, 89-91, 94, 150-293, 312-323, 334-344
terratorch/models/scalar_output_model.py                          58     16     16      4    68%   14-15, 58-64, 74, 77, 80, 104-105, 112-113, 115-116
terratorch/models/smp_model_factory.py                           130     52     42     13    54%   62, 65, 68, 72, 75, 127-128, 137-138, 145->152, 147, 154-171, 206, 228, 229->exit, 233-239, 244, 250-253, 257, 262-265, 271-287, 291-292
terratorch/models/timm_model_factory.py                           43     26     14      0    30%   42-66, 71-72, 75, 78-81, 84-85
terratorch/models/utils.py                                        35      4     18      4    85%   26, 32, 38, 46
terratorch/models/wxc_model_factory.py                           124    104     34      0    13%   24-25, 28-30, 33-35, 38-39, 42, 54-179
terratorch/registry/__init__.py                                    6      0      0      0   100%
terratorch/registry/custom_registry.py                            11      3      2      1    69%   13-15
terratorch/registry/mmseg_registry.py                             59     35      8      1    37%   34-35, 38, 47-51, 54, 60-75, 78, 81, 84, 87, 90, 93-97, 101-102
terratorch/registry/registry.py                                  116     13     30      5    85%   11->exit, 12->exit, 13->exit, 48->47, 50-51, 84-86, 89, 103-104, 107-108, 111, 168, 171
terratorch/registry/smp_registry.py                               65     15      6      3    75%   58-59, 64, 69-71, 81->84, 113, 116, 119, 124-126, 129, 132, 141
terratorch/registry/timm_registry.py                              49     16      2      0    65%   12-15, 19, 23, 41, 56-60, 63, 66, 69, 75, 78
terratorch/samplers/__init__.py                                    1      1      0      0     0%   3
terratorch/samplers/single.py                                     28     28      6      0     0%   3-38
terratorch/tasks/__init__.py                                      18      4      2      1    75%   12-15, 26->exit
terratorch/tasks/base_task.py                                     82     26     28      7    63%   36-39, 47-48, 52, 55, 66, 75-76, 95-98, 105-124, 149
terratorch/tasks/classification_tasks.py                         108     47     22      6    58%   24-25, 117, 119, 121->124, 128, 159-160, 204, 218-228, 238-246, 256-271, 284-292
terratorch/tasks/loss_handler.py                                  37     19     10      2    43%   48-70, 92
terratorch/tasks/multilabel_classification_tasks.py               63     45      4      0    27%   25-30, 35-40, 43-59, 63-64, 67-78, 81-89, 92-100
terratorch/tasks/optimizer_factory.py                             17     11      2      0    32%   34-46
terratorch/tasks/regression_tasks.py                             187     38     50     17    73%   42-46, 71, 74, 79-80, 100->104, 107-111, 117, 209, 211, 213->216, 220, 238, 251-252, 273, 322->exit, 328, 333->344, 337-342, 362-363, 384-397
terratorch/tasks/segmentation_tasks.py                           153     31     48     13    74%   132, 134, 136->139, 143, 164-167, 187-190, 197-200, 246, 290-291, 319->exit, 325-330, 336->347, 340-345, 360-382
terratorch/tasks/tiled_inference.py                               64      8     24      6    84%   117-118, 140, 171, 180, 194-195, 198
terratorch/tasks/wxc_downscaling_task.py                         144    122     18      0    14%   36-116, 119-125, 130-133, 152-164, 168-177, 181-191, 201-211, 214, 217-221
terratorch/tasks/wxc_task.py                                      29     17      4      0    36%   11-18, 21, 24-32, 35, 38
terratorch/utils.py                                               83     36     18      1    55%   43, 47-55, 79-89, 97-126
terratorch/validate_config.py                                     26     26      0      0     0%   1-28
tests/__init__.py                                                  0      0      0      0   100%
tests/test_backbones.py                                          100      2      4      0    98%   31, 36
tests/test_clay_tasks.py                                          41      3      6      1    91%   22, 84-85
tests/test_datasets.py                                           660     18     60      0    97%   56-84
tests/test_decoders.py                                            34      0      0      0   100%
tests/test_encoder_decoder_model_factory.py                      216     26     62      0    88%   203-221, 230-254, 263-288
tests/test_encoder_decoder_torchgeo_models.py                     97      0      8      0   100%
tests/test_finetune.py                                            55      0      2      0   100%
tests/test_generic_dataset.py                                    106      0     10      0   100%
tests/test_multi_source_registry.py                               61      4      0      0    93%   21, 24, 102, 113
tests/test_prithvi_model_factory.py                               97      0     18      0   100%
tests/test_prithvi_tasks.py                                       87      1     24      0    99%   28
tests/test_prithvi_vit.py                                         27      0      0      0   100%
tests/test_registry.py                                            50      4      0      0    92%   22, 63, 67, 84
tests/test_smp_model_factory.py                                   41      0      0      0   100%
tests/test_train.py                                                2      0      0      0   100%
----------------------------------------------------------------------------------------------------------
TOTAL                                                          14238   4853   3186    564    61%
========== 489 passed, 9 skipped, 372 warnings in 1205.40s (0:20:05) ===========
0s
0s

```