### PR TITLE
Using lists to define instructions about how to output predictions

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -206,28 +206,30 @@ class CustomWriter(BasePredictionWriter):
         if isinstance(prediction, torch.Tensor):
             filename_batch = ''.join(random.choices(string.ascii_letters + string.digits, k=8))
             torch.save(prediction, os.path.join(output_dir, f"{filename_batch}.pt"))
+
         elif isinstance(prediction, tuple):
 
             pred_batch_, filename_batch = prediction
 
+            # If we have just a single kind of output
             if isinstance(pred_batch_, tuple):
-                pred_batch, pred_batch_prob = pred_batch_
-                outputting_logits = True
-            else:
-                pred_batch = pred_batch_
-                outputting_logits = False
 
-            for prediction, file_name in zip(torch.unbind(pred_batch, dim=0), filename_batch, strict=False):
-                save_prediction(prediction, file_name, output_dir, dtype=trainer.out_dtype)
+                pred_batch, suffix = pred_batch_
 
-            # Special conditions for segmentation, when the
-            # logits/probabilities can be outputted together with the
-            # prediction. 
-            if outputting_logits:
-                for prediction, file_name in zip(torch.unbind(pred_batch_prob, dim=0), filename_batch, strict=False):
+                for prediction, file_name in zip(torch.unbind(pred_batch, dim=0), filename_batch, strict=False):
                     save_prediction(prediction, file_name, output_dir,
-                                    dtype=trainer.out_dtype,
-                                    suffix="logits_pred")
+                                    dtype=trainer.out_dtype, suffix=suffix)
+
+            # If we are outputting more than one kind of variable, as
+            # (predictions, probabilities), for segmentation
+            elif isinstance(pred_batch_, list):
+
+                for pred in pred_batch_:
+                    pred_batch, suffix = pred
+
+                    for p, file_name in zip(torch.unbind(pred_batch, dim=0), filename_batch, strict=False):
+                        save_prediction(p, file_name, output_dir,
+                                        dtype=trainer.out_dtype, suffix=suffix)
 
         else:
             raise TypeError(f"Unknown type for prediction {type(prediction)}")

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -159,11 +159,13 @@ class SemanticSegmentationTask(TerraTorchTask):
 
         # Processing the `output_on_inference` argument.
         self.output_prediction = lambda y: (y.argmax(dim=1), "pred")
-        self.output_probabilities = lambda y: (y, "logits")
+        self.output_logits = lambda y: (y, "logits")
+        self.output_probabilities = lambda y: (torch.nn.Softmax()(y), "probabilities")
 
         # The possible methods to define outputs.
         self.operation_map = {
                               "prediction": self.output_prediction, 
+                              "logits": self.output_logits, 
                               "probabilities": self.output_probabilities
                               }
 

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -151,7 +151,7 @@ class SemanticSegmentationTask(TerraTorchTask):
         self.plot_on_val = int(plot_on_val)
         self.output_on_inference = output_on_inference
 
-        # When the use decides to use `output_most_probable` as `False` in
+        # When the user decides to use `output_most_probable` as `False` in
         # order to output the probabilities instead of the prediction.
         if not output_most_probable:
             warnings.warn("The argument `output_most_probable` is deprecated and will be replaced with `output_on_inference='probabilities'`.", stacklevel=1)
@@ -161,11 +161,13 @@ class SemanticSegmentationTask(TerraTorchTask):
         self.output_prediction = lambda y: (y.argmax(dim=1), "pred")
         self.output_probabilities = lambda y: (y, "logits")
 
+        # The possible methods to define outputs.
         self.operation_map = {
                               "prediction": self.output_prediction, 
                               "probabilities": self.output_probabilities
                               }
 
+        # `output_on_inference` can be a list or a string.
         if isinstance(output_on_inference, list):
             list_of_selectors = ()
             for var in output_on_inference:
@@ -181,6 +183,9 @@ class SemanticSegmentationTask(TerraTorchTask):
                                                    list_of_selectors]
         elif isinstance(output_on_inference, str):
             self.select_classes = self.operation_map[output_on_inference]
+
+        else:
+            raise ValueError("The value {output_on_inference} isn't supported for `output_on_inference`.")
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion.

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -68,7 +68,7 @@ class SemanticSegmentationTask(TerraTorchTask):
         tiled_inference_parameters: TiledInferenceParameters = None,
         test_dataloaders_names: list[str] | None = None,
         lr_overrides: dict[str, float] | None = None,
-        output_on_inference: str = "prediction",
+        output_on_inference: str | list[str] = "prediction",
         output_most_probable: bool = True,
         tiled_inference_on_testing: bool = False,
     ) -> None:
@@ -116,7 +116,7 @@ class SemanticSegmentationTask(TerraTorchTask):
             lr_overrides (dict[str, float] | None, optional): Dictionary to override the default lr in specific
                 parameters. The key should be a substring of the parameter names (it will check the substring is
                 contained in the parameter name)and the value should be the new lr. Defaults to None.
-            output_on_inference (str): A string defining the kind of output to be saved to file during the inference, it can be "prediction",
+            output_on_inference (str | list[str]): A string defining the kind of output to be saved to file during the inference, it can be "prediction",
             to save just the most probable class, "probabilities", to save probabilities for all the classes or "both", to save both the 
             kinds of outputs to dedicated files. 
             output_most_probable (bool): A boolean to define if the prediction step will output just the most probable
@@ -157,15 +157,30 @@ class SemanticSegmentationTask(TerraTorchTask):
             warnings.warn("The argument `output_most_probable` is deprecated and will be replaced with `output_on_inference='probabilities'`.", stacklevel=1)
             output_on_inference = "probabilities"
 
-        if output_on_inference == "prediction":
-            self.select_classes = lambda y: y.argmax(dim=1) 
-        elif output_on_inference == "probabilities":
-            self.select_classes = lambda y: y
-        elif output_on_inference == "both":
-            self.select_classes = lambda y: (y.argmax(dim=1), y)
-        else:
-            raise ValueError(f"Invalid value for output_on_inference as {output_on_inference},\
-                             it must be `prediction`, `probabilities` or `both`")
+        # Processing the `output_on_inference` argument.
+        self.output_prediction = lambda y: (y.argmax(dim=1), "pred")
+        self.output_probabilities = lambda y: (y, "logits")
+
+        self.operation_map = {
+                              "prediction": self.output_prediction, 
+                              "probabilities": self.output_probabilities
+                              }
+
+        if isinstance(output_on_inference, list):
+            list_of_selectors = ()
+            for var in output_on_inference:
+                if var in self.operation_map:
+                    list_of_selectors += (self.operation_map[var],)
+                else:
+                    warnings.warn(f"Option {var} is not supported.")
+
+            if not len(list_of_selectors):
+                raise ValueError("The list of selectors for the output is empty, please, provide a valid value for `output_on_inference`")
+
+            self.select_classes = lambda y: [op(y) for op in
+                                                   list_of_selectors]
+        elif isinstance(output_on_inference, str):
+            self.select_classes = self.operation_map[output_on_inference]
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion.

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -118,7 +118,8 @@ class SemanticSegmentationTask(TerraTorchTask):
                 contained in the parameter name)and the value should be the new lr. Defaults to None.
             output_on_inference (str | list[str]): A string or a list defining the kind of output to be saved to file during the inference, for example,
             it can be "prediction", to save just the most probable class, or ["prediction", "probabilities"] to save both prediction and probabilities.
-            output_most_probable (bool): A boolean to define if the prediction step will output just the most probable
+            output_most_probable (bool): A boolean to define if the prediction step will output just the most probable. This argument has been deprecated and will
+                be replaced with `output_on_inference`. 
             class or the probabilities for all of them. This argument has been deprecated and will be replaced with `output_on_inference`. 
             tiled_inference_on_testing (bool): A boolean to the fine if tiled inference will be used when full inference 
                 fails during the test step. 
@@ -184,7 +185,7 @@ class SemanticSegmentationTask(TerraTorchTask):
             self.select_classes = self.operation_map[output_on_inference]
 
         else:
-            raise ValueError("The value {output_on_inference} isn't supported for `output_on_inference`.")
+            raise ValueError(f"The value {output_on_inference} isn't supported for `output_on_inference`.")
 
     def configure_losses(self) -> None:
         """Initialize the loss criterion.

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -116,9 +116,8 @@ class SemanticSegmentationTask(TerraTorchTask):
             lr_overrides (dict[str, float] | None, optional): Dictionary to override the default lr in specific
                 parameters. The key should be a substring of the parameter names (it will check the substring is
                 contained in the parameter name)and the value should be the new lr. Defaults to None.
-            output_on_inference (str | list[str]): A string defining the kind of output to be saved to file during the inference, it can be "prediction",
-            to save just the most probable class, "probabilities", to save probabilities for all the classes or "both", to save both the 
-            kinds of outputs to dedicated files. 
+            output_on_inference (str | list[str]): A string or a list defining the kind of output to be saved to file during the inference, for example,
+            it can be "prediction", to save just the most probable class, or ["prediction", "probabilities"] to save both prediction and probabilities.
             output_most_probable (bool): A boolean to define if the prediction step will output just the most probable
             class or the probabilities for all of them. This argument has been deprecated and will be replaced with `output_on_inference`. 
             tiled_inference_on_testing (bool): A boolean to the fine if tiled inference will be used when full inference 

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -176,7 +176,7 @@ class SemanticSegmentationTask(TerraTorchTask):
                 if var in self.operation_map:
                     list_of_selectors += (self.operation_map[var],)
                 else:
-                    warnings.warn(f"Option {var} is not supported.")
+                    raise ValueError(f"Option {var} is not supported. It must be in ['prediction', 'logits', 'probabilities']")
 
             if not len(list_of_selectors):
                 raise ValueError("The list of selectors for the output is empty, please, provide a valid value for `output_on_inference`")

--- a/tests/resources/configs/manufactured-finetune_prithvi_swin_B_segmentation.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_swin_B_segmentation.yaml
@@ -102,6 +102,7 @@ model:
     output_on_inference: 
       - probabilities
       - prediction
+      - logits
     tiled_inference_on_testing: true
     loss: ce
     #aux_heads:

--- a/tests/resources/configs/manufactured-finetune_prithvi_swin_B_segmentation.yaml
+++ b/tests/resources/configs/manufactured-finetune_prithvi_swin_B_segmentation.yaml
@@ -99,8 +99,9 @@ model:
       num_frames: 1
       num_classes: 2
       head_dropout: 0.5708022831486758
-        #output_on_inference: probabilities #both
-    output_most_probable: False
+    output_on_inference: 
+      - probabilities
+      - prediction
     tiled_inference_on_testing: true
     loss: ce
     #aux_heads:


### PR DESCRIPTION
* Using a string, as `"prediction"`  to output just predictions.
* Using a list as `["prediction", "probabilities"]`  to output both predictions and `probabilities/logits`. 