### PR TITLE
Update get_common_prefix to handle cases where len(prefix_list) < 1

### DIFF
--- a/terratorch/datasets/multi_temporal_crop_classification.py
+++ b/terratorch/datasets/multi_temporal_crop_classification.py
@@ -157,7 +157,7 @@ class MultiTemporalCropClassification(NonGeoDataset):
         temporal_coords = []
         for col in self.date_columns:
             date_str = row[col]
-            date = pd.to_datetime(date_str, infer_datetime_format=True)
+            date = pd.to_datetime(date_str)
             temporal_coords.append([date.year, date.dayofyear - 1])
 
         return torch.tensor(temporal_coords, dtype=torch.float32)

--- a/terratorch/models/backbones/select_patch_embed_weights.py
+++ b/terratorch/models/backbones/select_patch_embed_weights.py
@@ -48,10 +48,13 @@ def get_common_prefix(keys):
 
     if len(prefix_list) > 1:
         prefix = ".".join(prefix_list)
-    else:
+    elif len(prefix_list) == 1:
         prefix = prefix_list.pop()
+        prefix = prefix + "."
+    else:
+        prefix = None
 
-    return prefix + "."
+    return prefix
 
 def get_proj_key(state_dict, encoder_only=True, return_prefix=False):
 


### PR DESCRIPTION
While working with PrithviMAE by setting `"backbone_encoder_only" = False` I got an error with the function `get_common_prefix` from models/backbone/select_patch_embed_weights.py.
There was no common prefix in my state_dict so prefix_list was an empty set and the else condition led to :
> KeyError: 'pop from an empty set'

Moreover I think that the intended return statement is `prefix` and not `prefix + "."`.


I also removed the argument `infer_datetime_format=True` in datasets/multi_temporal_crop_classification.py as it spams warnings.
infer_datetime_format is deprecated since pandas version 2.0.0 as stated in the docs : [pandas.to_datetime](https://pandas.pydata.org/docs/reference/api/pandas.to_datetime.html)