### PR TITLE
Imagefolder/dummy tiff file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "h5py",
   "mlflow",
   "lightning",
-  "segmentation-models-pytorch",
+  "segmentation-models-pytorch<=0.4.0",
   "jsonargparse",
   "pytest",
   "torchgeo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "einops",
   "timm>=1.0.15",
   "huggingface_hub",
+  "tifffile"
 ]
 
 [project.optional-dependencies]

--- a/tests/datamodules/test_genericscalarlabeldatamodule.py
+++ b/tests/datamodules/test_genericscalarlabeldatamodule.py
@@ -21,6 +21,24 @@ def dummy_classification_data(tmp_path):
 
     return root
 
+@pytest.fixture
+def dummy_classification_data_float(tmp_path):
+    root = tmp_path / "cls_data"
+    root.mkdir()
+
+    def create_image_file(p, shape=(16,16,3), pixel_values=[0.1, 0.2, 0.3, 0.4]):
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        create_dummy_tiff(str(p), shape=shape, pixel_values=pixel_values)
+
+    for split in ["train", "val", "test", "predict"]:
+        for class_label in ["class0", "class1"]:
+            (root / split / class_label).mkdir(parents=True, exist_ok=True)
+            sample_tif = root / split / class_label / "sample1.tif"
+            create_image_file(sample_tif)
+
+    return root
+
+
 def test_generic_non_geo_classification_datamodule(dummy_classification_data):
     from terratorch.datamodules.generic_scalar_label_data_module import GenericNonGeoClassificationDataModule
     dm = GenericNonGeoClassificationDataModule(
@@ -55,5 +73,49 @@ def test_generic_non_geo_classification_datamodule(dummy_classification_data):
     pred_loader = dm.predict_dataloader()
     pred_batch = next(iter(pred_loader))
     assert "image" in pred_batch
+
+    gc.collect()
+
+def test_generic_non_geo_classification_datamodule_float(dummy_classification_data_float):
+    from terratorch.datamodules.generic_scalar_label_data_module import GenericNonGeoClassificationDataModule
+    dm = GenericNonGeoClassificationDataModule(
+        batch_size=2,
+        num_workers=0,
+        train_data_root=dummy_classification_data_float / "train",
+        val_data_root=dummy_classification_data_float / "val",
+        test_data_root=dummy_classification_data_float / "test",
+        predict_data_root=dummy_classification_data_float / "predict",
+        means=[0, 0, 0],
+        stds=[1, 1, 1],
+        num_classes=2,
+        drop_last=False,
+    )
+
+    dm.setup("fit")
+    train_loader = dm.train_dataloader()
+    train_batch = next(iter(train_loader))
+    assert "image" in train_batch
+    assert "label" in train_batch
+    assert train_batch["image"].max() == 0.4
+
+    dm.setup("validate")
+    val_loader = dm.val_dataloader()
+    val_batch = next(iter(val_loader))
+    assert "image" in val_batch
+    assert "label" in val_batch
+    assert train_batch["image"].max() == 0.4
+
+    dm.setup("test")
+    test_loader = dm.test_dataloader()
+    test_batch = next(iter(test_loader))
+    assert "image" in test_batch
+    assert "label" in test_batch
+    assert train_batch["image"].max() == 0.4
+
+    dm.setup("predict")
+    pred_loader = dm.predict_dataloader()
+    pred_batch = next(iter(pred_loader))
+    assert "image" in pred_batch
+    assert train_batch["image"].max() == 0.4
 
     gc.collect()

--- a/tests/datamodules/utils.py
+++ b/tests/datamodules/utils.py
@@ -8,9 +8,14 @@ from PIL import Image
 from rasterio.transform import from_origin
 
 
-def create_dummy_tiff(path: str, shape: tuple, pixel_values, min_size: int = None) -> None:
+def create_dummy_tiff(path: str, shape: tuple, pixel_values: int | list, min_size: int = None) -> None:
 
-    if not all([type(i)==int for i in pixel_values]):
+    if type(pixel_values) == int:
+        pixel_values_ = [pixel_values]
+    else:
+        pixel_values_ = pixel_values
+
+    if not all([type(i)==int for i in pixel_values_]):
         dtype = np.float32
     else:
         dtype = np.uint8

--- a/tests/datamodules/utils.py
+++ b/tests/datamodules/utils.py
@@ -9,6 +9,12 @@ from rasterio.transform import from_origin
 
 
 def create_dummy_tiff(path: str, shape: tuple, pixel_values, min_size: int = None) -> None:
+
+    if not all([type(i)==int for i in pixel_values]):
+        dtype = np.float32
+    else:
+        dtype = np.uint8
+
     os.makedirs(os.path.dirname(path), exist_ok=True)
     if min_size is not None:
         if len(shape) == 3:
@@ -23,10 +29,10 @@ def create_dummy_tiff(path: str, shape: tuple, pixel_values, min_size: int = Non
             shape = (h, w)
     if len(shape) == 3:
         h, w, c = shape
-        data = np.random.choice(pixel_values, size=(h, w, c), replace=True).astype(np.uint8)
+        data = np.random.choice(pixel_values, size=(h, w, c), replace=True).astype(dtype)
         data = np.transpose(data, (2, 0, 1))
     elif len(shape) == 2:
-        data = np.random.choice(pixel_values, size=shape, replace=True).astype(np.uint8)
+        data = np.random.choice(pixel_values, size=shape, replace=True).astype(dtype)
         data = data[np.newaxis, ...]
     transform = from_origin(0, 0, 1, 1)
     with rasterio.open(
@@ -42,16 +48,22 @@ def create_dummy_tiff(path: str, shape: tuple, pixel_values, min_size: int = Non
         dst.write(data)
 
 def create_dummy_image(path: str, shape: tuple, pixel_values: list[int]) -> None:
+
+    if not all([type(i)==int for i in pixel_values]):
+        dtype = np.float32
+    else:
+        dtype = np.uint8
+
     ext = os.path.splitext(path)[1].lower()
     os.makedirs(os.path.dirname(path), exist_ok=True)
     if ext in [".tif", ".tiff"]:
         create_dummy_tiff(path, shape, pixel_values)
     else:
         if len(shape) == 3:
-            data = np.random.choice(pixel_values, size=shape, replace=True).astype(np.uint8)
+            data = np.random.choice(pixel_values, size=shape, replace=True).astype(dtype)
             img = Image.fromarray(data)
         elif len(shape) == 2:
-            data = np.random.choice(pixel_values, size=shape, replace=True).astype(np.uint8)
+            data = np.random.choice(pixel_values, size=shape, replace=True).astype(dtype)
             img = Image.fromarray(data)
         else:
             msg = "Invalid shape"


### PR DESCRIPTION
There was an issues when the user generated a floating-point image. The images were recorded and loaded as tensors of zeroes. 
* The new dummy image generator will handle floating-point cases.
* The new dataset `__getitem__` method will manage when load floating-point images without truncating them to zero. 