### PR TITLE
Pin smp version to avoid breaking change

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dependencies = [
   "h5py",
   "mlflow",
   "lightning",
-  "segmentation-models-pytorch",
+  "segmentation-models-pytorch==0.4.0",
   "jsonargparse",
   "pytest",
   "torchgeo",


### PR DESCRIPTION
`segmentation_models.pytorch` recently released a [new version (**v0.5.0**)](https://github.com/qubvel-org/segmentation_models.pytorch/releases/tag/v0.5.0), which introduces breaking changes that affect the terraform package, specifically the SMP-related modules (SMPModelFactory, UNetDecoder, ...).

```bash
`TypeError: UnetDecoder.__init__() got an unexpected keyword argument 'use_batchnorm'
```

Simple solution is to pin `segmentation_models.pytorch` to the last compatible version (0.4.0), and eventually adapt the different components to incorporate this new change.


