### PR TITLE
We don't need to run the tests when a notebook is changed

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,7 @@ on:
       - 'tests/resources/**'
       - '**/*.svg'
       - '**/*.png'
+      - '**/*.ipynb'
   pull_request:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - 'tests/resources/**'
       - '**/*.svg'
       - '**/*.png'
+      - '**/*.ipynb'
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When we modify a notebook in the examples, we don't need to run all the automatic tests. They have no effect over the source code. In this way we should exclude all the `*.ipynb` files from the tests list. 