### PR TITLE
Dealing with cases in which the prediction is a tuple(tuple, str)

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -655,7 +655,14 @@ class LightningInferenceModel:
         if data_root:
             self.datamodule.predict_root = data_root
         predictions = self.trainer.predict(model=self.model, datamodule=self.datamodule, return_predictions=True)
-        concat_predictions = torch.cat([batch[0] for batch in predictions])
+
+        # In some cases, the output has the format ((prediction_tensor,
+        # prediction_name), filename)
+        if all([type(j[0])==tuple for j in predictions]):
+            concat_predictions = torch.cat([batch[0][0] for batch in predictions])
+        else:
+            concat_predictions = torch.cat([batch[0] for batch in predictions])
+
         concat_file_names = flatten([batch[1] for batch in predictions])
 
         return concat_predictions, concat_file_names


### PR DESCRIPTION
For example:
```
Predicting DataLoader 0: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:02<00:00,  0.35it/s]
[((tensor([[[0, 0, 0,  ..., 0, 0, 0],
         [0, 0, 0,  ..., 0, 0, 0],
         [0, 0, 0,  ..., 0, 0, 0],
         ...,
         [0, 0, 0,  ..., 0, 0, 0],
         [0, 0, 0,  ..., 0, 0, 0],
         [0, 0, 0,  ..., 0, 0, 0]]]), 'pred'), ['/tmp/myfile.tif'])]

```
In these case the concatenation will fail in `terratorch/terratorch/cli_tools.py", line 659`