### PR TITLE
Cleaning pip cache for GH runners

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -39,6 +39,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .[wxc,test]
+      - name: Clean pip cache
+        run: pip cache purge
       - name: List pip dependencies
         run: pip list
       - name: Test with pytest


### PR DESCRIPTION
Doing a PR in order to avoid replicating this commit for all the others PRs.
The tests have been interrupted due to low space in the GH runner disk.  