### PR TITLE
A way to avoid the list of mask files be emtpy

### DIFF
--- a/terratorch/datasets/generic_pixel_wise_dataset.py
+++ b/terratorch/datasets/generic_pixel_wise_dataset.py
@@ -120,10 +120,10 @@ class GenericPixelWiseDataset(NonGeoDataset, ABC):
         # We don't define a split file for prediction
         if not self.split_file:
             # When prediction is enabled, we don't have mask files, so
-            # we need to provide a way to run the dataloder in this cases.
+            # we need to provide a way to run the dataloder in these cases.
             if not self.segmentation_mask_files:
                 self.segmentation_mask_files = self.image_files
-                # The masks can be `None` sinc ethey won't be used in fact. 
+                # The masks can be `None` since they won't be used in fact. 
 
         self.rgb_indices = [0, 1, 2] if rgb_indices is None else rgb_indices
 

--- a/terratorch/datasets/generic_pixel_wise_dataset.py
+++ b/terratorch/datasets/generic_pixel_wise_dataset.py
@@ -116,6 +116,15 @@ class GenericPixelWiseDataset(NonGeoDataset, ABC):
                 ignore_extensions=ignore_split_file_extensions,
                 allow_substring=allow_substring_split_file,
             )
+
+        # We don't define a split file for prediction
+        if not self.split_file:
+            # When prediction is enabled, we don't have mask files, so
+            # we need to provide a way to run the dataloder in this cases.
+            if not self.segmentation_mask_files:
+                self.segmentation_mask_files = self.image_files
+                # The masks can be `None` sinc ethey won't be used in fact. 
+
         self.rgb_indices = [0, 1, 2] if rgb_indices is None else rgb_indices
 
         self.dataset_bands = generate_bands_intervals(dataset_bands)


### PR DESCRIPTION
For prediction, when we don't used to consider `img_grep` and `label_grep`, the input files were also copied as masks (which isn't critical, since the masks aren't used in this case). After the inclusion of these arguments, the list of mask files has became emtpy, so this fix tries to recover the previous behavior. 