### PR TITLE
Fix/clay1 wavelenghts

### DIFF
--- a/terratorch/models/backbones/clay_v1/modules.py
+++ b/terratorch/models/backbones/clay_v1/modules.py
@@ -12,19 +12,6 @@ from terratorch.models.backbones.clay_v1.utils import posemb_sincos_1d, posemb_s
 os.environ["TORCH_CUDNN_V8_API_DISABLED"] = "1"
 
 # central wavelengths of pretrained model
-# WAVELENGTHS = {
-#     "blue": 0.493,
-#     "green": 0.56,
-#     "red": 0.665,
-#     "rededge1": 0.704,
-#     "rededge2": 0.74,
-#     "rededge3": 0.783,
-#     "nir": 0.842,
-#     "nir08": 0.865,
-#     "swir16": 1.61,
-#     "swir22": 2.19,
-# }
-
 WAVELENGTHS= {
   "COASTAL_AEROSOL": 0.44,
   "BLUE": 0.49,

--- a/terratorch/models/backbones/clay_v1/modules.py
+++ b/terratorch/models/backbones/clay_v1/modules.py
@@ -12,18 +12,44 @@ from terratorch.models.backbones.clay_v1.utils import posemb_sincos_1d, posemb_s
 os.environ["TORCH_CUDNN_V8_API_DISABLED"] = "1"
 
 # central wavelengths of pretrained model
-WAVELENGTHS = {
-    "blue": 0.493,
-    "green": 0.56,
-    "red": 0.665,
-    "rededge1": 0.704,
-    "rededge2": 0.74,
-    "rededge3": 0.783,
-    "nir": 0.842,
-    "nir08": 0.865,
-    "swir16": 1.61,
-    "swir22": 2.19,
-}
+# WAVELENGTHS = {
+#     "blue": 0.493,
+#     "green": 0.56,
+#     "red": 0.665,
+#     "rededge1": 0.704,
+#     "rededge2": 0.74,
+#     "rededge3": 0.783,
+#     "nir": 0.842,
+#     "nir08": 0.865,
+#     "swir16": 1.61,
+#     "swir22": 2.19,
+# }
+
+WAVELENGTHS= {
+  "COASTAL_AEROSOL": 0.44,
+  "BLUE": 0.49,
+  "GREEN": 0.56,
+  "RED": 0.665,
+  "RED_EDGE_1": 0.705,
+  "RED_EDGE_2": 0.74, 
+  "RED_EDGE_3": 0.783,
+  "NIR_BROAD": 0.832,
+  "NIR_NARROW": 0.864,
+  "WATER_VAPOR": 0.945,
+  "CIRRUS": 1.373,
+  "SWIR_1": 1.61,
+  "SWIR_2": 2.20,
+  "THEMRAL_INFRARED_1": 10.90,
+  "THEMRAL_INFRARED_12": 12.00, 
+  "VV": 5.405,
+  "VH": 5.405,
+  "ASC_VV": 5.405,
+  "ASC_VH": 5.405,
+  "DSC_VV": 5.405,
+  "DSC_VH": 5.405,
+  "VV-VH": 5.405
+  }
+
 
 
 class FeedForward(nn.Module):
@@ -571,7 +597,10 @@ class Datacuber(nn.Module):
         return datacube
 
     def _parse_wavelengths(self, bands, channels):
-        if bands is not None and all([_ in WAVELENGTHS for _ in bands]):
-            return torch.tensor([WAVELENGTHS[_] for _ in bands])
-        else:
-            return torch.zeros(channels)
+        waves = torch.tensor([WAVELENGTHS[band] if band in WAVELENGTHS.keys() else 0.0 for band in bands])
+        print(waves)
+        return waves
+        # if bands is not None and all([_ in WAVELENGTHS for _ in bands]):
+        #     return torch.tensor([WAVELENGTHS[_] for _ in bands])
+        # else:
+        #     return torch.zeros(channels)

--- a/terratorch/models/backbones/clay_v1/modules.py
+++ b/terratorch/models/backbones/clay_v1/modules.py
@@ -13,6 +13,16 @@ os.environ["TORCH_CUDNN_V8_API_DISABLED"] = "1"
 
 # central wavelengths of pretrained model
 WAVELENGTHS= {
+  "blue": 0.493,
+  "green": 0.56,
+  "red": 0.665,
+  "rededge1": 0.704,
+  "rededge2": 0.74,
+  "rededge3": 0.783,
+  "nir": 0.842,
+  "nir08": 0.865,
+  "swir16": 1.61,
+  "swir22": 2.19,
   "COASTAL_AEROSOL": 0.44,
   "BLUE": 0.49,
   "GREEN": 0.56,


### PR DESCRIPTION
I made 2 changes:
* Clay is based on DOFA and we had only a subset of possible wavelenghts of S2 bands with no S1 bands, I took the ones from DOFA and added them in (kept the old ones for back compatibility);
* We were throwing away with 0s all wavelengths if not all bands were matching which seems wrong to me. I made a change to keep what matches and pad with 0 in case a band is not matching;

@Joao-L-S-Almeida you were involved in onboarding this model, please have a look.