### PR TITLE
Update/custom modules/example

### DIFF
--- a/examples/custom_modules/alexnet.py
+++ b/examples/custom_modules/alexnet.py
@@ -2,6 +2,14 @@ import torch
 from terratorch.registry import TERRATORCH_BACKBONE_REGISTRY 
 
 @TERRATORCH_BACKBONE_REGISTRY.register
+def alexnet_encoder(num_channels:int=2, pretrained:bool=False):
+
+    backbone = AlexNetEncoder(num_channels=num_channels)
+    if pretrained:
+        print("This is my life")
+
+    return backbone
+
 class AlexNetEncoder(torch.nn.Module):
 
     def __init__(self, num_channels:int=3):

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -158,7 +158,7 @@ def import_custom_modules(custom_modules_path: str | Path | None = None) -> None
     if custom_modules_path:
 
         custom_modules_path = Path(custom_modules_path)
-        print(custom_modules_path)
+
         if custom_modules_path.is_dir():
 
             # Add 'custom_modules' folder to sys.path
@@ -169,7 +169,6 @@ def import_custom_modules(custom_modules_path: str | Path | None = None) -> None
 
             try:
                 module = importlib.import_module(module_dir)
-                print(module)
                 logger.info(f"Found {custom_modules_path}")
             except ImportError:
                 raise ImportError(f"It was not possible to import modules from {custom_modules_path}.")

--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -158,7 +158,7 @@ def import_custom_modules(custom_modules_path: str | Path | None = None) -> None
     if custom_modules_path:
 
         custom_modules_path = Path(custom_modules_path)
-
+        print(custom_modules_path)
         if custom_modules_path.is_dir():
 
             # Add 'custom_modules' folder to sys.path
@@ -169,6 +169,7 @@ def import_custom_modules(custom_modules_path: str | Path | None = None) -> None
 
             try:
                 module = importlib.import_module(module_dir)
+                print(module)
                 logger.info(f"Found {custom_modules_path}")
             except ImportError:
                 raise ImportError(f"It was not possible to import modules from {custom_modules_path}.")
@@ -462,7 +463,6 @@ class MyLightningCLI(LightningCLI):
         # callback. 
         self.config = add_default_checkpointing_config(self.config)
 
-        super().instantiate_classes()
 
         # get the predict_output_dir. Depending on the value of run, it may be in the subcommand
         try:
@@ -492,6 +492,7 @@ class MyLightningCLI(LightningCLI):
 
         import_custom_modules(custom_modules_path)
 
+        super().instantiate_classes()
 
     @staticmethod
     def subcommands() -> dict[str, set[str]]:


### PR DESCRIPTION
The modules sharing on sys.path must be before the classes instantiation.