### PR TITLE
fixes AugmentationSequential data_keys

### DIFF
--- a/terratorch/datamodules/fire_scars.py
+++ b/terratorch/datamodules/fire_scars.py
@@ -81,7 +81,7 @@ class FireScarsNonGeoDataModule(NonGeoDataModule):
         self.val_transform = wrap_in_compose_is_list(val_transform)
         self.test_transform = wrap_in_compose_is_list(test_transform)
         self.predict_transform = wrap_in_compose_is_list(predict_transform)
-        self.aug = AugmentationSequential(K.Normalize(means, stds), data_keys=["image"])
+        self.aug = AugmentationSequential(K.Normalize(means, stds), data_keys=None)
         self.drop_last = drop_last
         self.no_data_replace = no_data_replace
         self.no_label_replace = no_label_replace
@@ -166,8 +166,8 @@ class FireScarsDataModule(GeoDataModule):
         super().__init__(FireScarsSegmentationMask, 4, 224, 100, 0, **kwargs)
         means = list(MEANS.values())
         stds = list(STDS.values())
-        self.train_aug = AugmentationSequential(K.RandomCrop(224, 224), K.Normalize(means, stds))
-        self.aug = AugmentationSequential(K.Normalize(means, stds))
+        self.train_aug = AugmentationSequential(K.RandomCrop(224, 224), K.Normalize(means, stds), data_keys=None)
+        self.aug = AugmentationSequential(K.Normalize(means, stds), data_keys=None)
         self.data_root = data_root
 
     def setup(self, stage: str) -> None:
@@ -178,7 +178,7 @@ class FireScarsDataModule(GeoDataModule):
             os.path.join(self.data_root, "training/")
         )
         self.dataset = self.images & self.labels
-        self.train_aug = AugmentationSequential(K.RandomCrop(224, 224), K.normalize())
+        self.train_aug = AugmentationSequential(K.RandomCrop(224, 224), K.normalize(), data_keys=None)
 
         self.images_test = FireScarsHLS(
             os.path.join(self.data_root, "validation/")

--- a/terratorch/datamodules/geobench_data_module.py
+++ b/terratorch/datamodules/geobench_data_module.py
@@ -40,7 +40,7 @@ class GeobenchDataModule(NonGeoDataModule):
         self.data_root = data_root
         self.partition = partition
         self.aug = (
-            AugmentationSequential(K.Normalize(self.means, self.stds), data_keys=["image"]) if aug is None else aug
+            AugmentationSequential(K.Normalize(self.means, self.stds), data_keys=None) if aug is None else aug
         )
 
     def setup(self, stage: str) -> None:

--- a/terratorch/datamodules/landslide4sense.py
+++ b/terratorch/datamodules/landslide4sense.py
@@ -86,7 +86,7 @@ class Landslide4SenseNonGeoDataModule(NonGeoDataModule):
         self.test_transform = wrap_in_compose_is_list(test_transform)
         self.predict_transform = wrap_in_compose_is_list(predict_transform)
         self.aug = (
-            AugmentationSequential(K.Normalize(self.means, self.stds), data_keys=["image"]) if aug is None else aug
+            AugmentationSequential(K.Normalize(self.means, self.stds), data_keys=None) if aug is None else aug
         )
 
     def setup(self, stage: str) -> None:

--- a/terratorch/datamodules/openearthmap.py
+++ b/terratorch/datamodules/openearthmap.py
@@ -59,7 +59,7 @@ class OpenEarthMapNonGeoDataModule(NonGeoDataModule):
         self.test_transform = wrap_in_compose_is_list(test_transform)
         self.predict_transform = wrap_in_compose_is_list(predict_transform)
         self.data_root = data_root
-        self.aug = AugmentationSequential(K.Normalize(self.means, self.stds), data_keys=["image"]) if aug is None else aug
+        self.aug = AugmentationSequential(K.Normalize(self.means, self.stds), data_keys=None) if aug is None else aug
 
     def setup(self, stage: str) -> None:
         """Set up datasets.

--- a/terratorch/datamodules/sen1floods11.py
+++ b/terratorch/datamodules/sen1floods11.py
@@ -94,7 +94,7 @@ class Sen1Floods11NonGeoDataModule(NonGeoDataModule):
         self.val_transform = wrap_in_compose_is_list(val_transform)
         self.test_transform = wrap_in_compose_is_list(test_transform)
         self.predict_transform = wrap_in_compose_is_list(predict_transform)
-        self.aug = AugmentationSequential(K.Normalize(means, stds), data_keys=["image"])
+        self.aug = AugmentationSequential(K.Normalize(means, stds), data_keys=None)
         self.drop_last = drop_last
         self.constant_scale = constant_scale
         self.no_data_replace = no_data_replace


### PR DESCRIPTION
Fixes the error below by fixing AugmentationSequential data_keys.

```
 File "/opt/conda/lib/python3.11/site-packages/kornia/augmentation/container/augment.py", line 439, in forward
    original_keys, data_keys, args, invalid_data = self._preproc_dict_data(args[0])
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/conda/lib/python3.11/site-packages/kornia/augmentation/container/augment.py", line 547, in _preproc_dict_data
    raise ValueError("If you are using a dictionary as input, the data_keys should be None.")
ValueError: If you are using a dictionary as input, the data_keys should be None.
```