### PR TITLE
Rename the image and label greps to tif wildcard

### DIFF
--- a/terratorch/cli_tools.py
+++ b/terratorch/cli_tools.py
@@ -289,7 +289,11 @@ def clean_config_for_deployment_and_dump(config: dict[str, Any]):
             deploy_config["model"]["init_args"]["model_args"]["pretrained"] = False
         elif "backbone_pretrained" in deploy_config["model"]["init_args"]["model_args"]:
             deploy_config["model"]["init_args"]["model_args"]["backbone_pretrained"] = False
-
+            
+    # Set image_grep and label_grep to *tif* . 
+    # Fixes issue with inference not finding image named as the training image.
+    deploy_config['data']['init_args']['img_grep'] = "*tif*"
+    deploy_config['data']['init_args']['label_grep'] = "*tif*"
     return yaml.safe_dump(deploy_config)
 
 


### PR DESCRIPTION
When the final config is created after finetuning a model, the config has the img_gep and label_grep as images used in the training set.
However, this doesn't hold when running predictions and the images could have any suffix.