### PR TITLE
Basic Configuration to use Pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.1
+    hooks:
+      - id: ruff
+        types_or:
+          - python
+          - jupyter
+        args:
+          - --fix
+      - id: ruff-format
+        types_or:
+          - python
+          - jupyter

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -15,7 +15,9 @@ automatically execute
 a pipeline with hundreds of unit and integration tests to verify that the package have not broken after the
 modification be merged to `main`. In this way, when an user wants to modify
 `terratorch` for adding new features or bufixes, this are the best practices. 
-
+* This repository uses `pre-commit`, a tool which automatically runs basic
+    steps before sending modifications to the remote (as linting, for example).
+    See how to configure it [here](https://pre-commit.com/#installation). 
 * If you are an user outside the IBM org, create a fork to add your modifications. If you are inside the IBM
     org or have received writing provileges, create a branch for it. 
 * If you are adding new features, we ask you to also add tests for it. These tests are defined in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,8 @@ dev = [
   "mkdocs-material",
   "mkdocstrings[python]",
   "mike", # for building docs with versions
-  "mkdocs-git-revision-date-localized-plugin"
+  "mkdocs-git-revision-date-localized-plugin",
+  "pre-commit"
 ]
 
 test = [


### PR DESCRIPTION
This basic configuration for [pre-commit](https://pre-commit.com/) allow us to automatically format  and lint code before sending it to the remote repository. It also enables reformatting the current code base in order to eliminate legacy modules, as `typing`:
* Running `pre-commit run --files <path>` will modify files contained in a specific path. 
* Running `pre-commit run --all-files` does it for the entire repository. 