### PR TITLE
Update tiled inference

### DIFF
--- a/terratorch/tasks/base_task.py
+++ b/terratorch/tasks/base_task.py
@@ -91,8 +91,7 @@ class TerraTorchTask(BaseTask):
                     y_hat: Tensor = tiled_inference(
                         model_forward,
                         x,
-                        num_categories, 
-                        self.tiled_inference_parameters,
+                        **self.tiled_inference_parameters,
                         **rest,
                     )
                     model_output = ModelOutput(output=y_hat)

--- a/terratorch/tasks/reconstruction_tasks.py
+++ b/terratorch/tasks/reconstruction_tasks.py
@@ -37,7 +37,7 @@ class ReconstructionTask(BaseTask):
             freeze_encoder: bool = False,  # noqa: FBT001, FBT002
             freeze_decoder: bool = False,  # noqa: FBT001, FBT002
             plot_on_val: bool | int = 10,
-            tiled_inference_parameters: TiledInferenceParameters | None = None,
+            tiled_inference_parameters: dict | None = None,
             modalities: list[str] | None = None
     ) -> None:
         """Constructor
@@ -69,7 +69,7 @@ class ReconstructionTask(BaseTask):
             freeze_decoder (bool, optional): Whether to freeze the decoder and segmentation head. Defaults to False.
             plot_on_val (bool | int, optional): Whether to plot visualizations on validation.
                 If true, log every epoch. Defaults to 10. If int, will plot every plot_on_val epochs.
-            tiled_inference_parameters (TiledInferenceParameters | None, optional): Inference parameters
+            tiled_inference_parameters (dict | None, optional): Inference parameters
                 used to determine if inference is done on the whole image or through tiling.
             modalities list(str), optional: List of modality names that are reconstructed. Expect reconstructions as
                 dict with modelity names as keys and tensors as values. Computes metrics for every modality.
@@ -369,15 +369,14 @@ class ReconstructionTask(BaseTask):
         def model_forward(x):
             out = self(x)[1]
             if isinstance(out, ReconstructionOutput):
-                pred  = out.pred
+                pred = out.pred
             else:
                 pred = out[1]
             return pred
 
         # Tiled inference for autoencoder ? Is it making sense ?
         if self.tiled_inference_parameters:
-            # TODO: tiled inference does not work with additional input data (**rest)
-            pred: torch.Tensor = tiled_inference(model_forward, x, 1, self.tiled_inference_parameters)
+            pred: torch.Tensor = tiled_inference(model_forward, x, **self.tiled_inference_parameters, **rest)
         else:
             pred: torch.Tensor = model_forward(x)
         # TODO: Return mask and file_names?

--- a/terratorch/tasks/regression_tasks.py
+++ b/terratorch/tasks/regression_tasks.py
@@ -154,7 +154,7 @@ class PixelwiseRegressionTask(TerraTorchTask):
         freeze_decoder: bool = False,  # noqa: FBT001, FBT002
         freeze_head: bool = False,  # noqa: FBT001, FBT002
         plot_on_val: bool | int = 10,
-        tiled_inference_parameters: TiledInferenceParameters | None = None,
+        tiled_inference_parameters: dict | None = None,
         test_dataloaders_names: list[str] | None = None,
         lr_overrides: dict[str, float] | None = None,
         tiled_inference_on_testing: bool = None,
@@ -192,7 +192,7 @@ class PixelwiseRegressionTask(TerraTorchTask):
             freeze_head (bool, optional): Whether to freeze the segmentation head. Defaults to False.
             plot_on_val (bool | int, optional): Whether to plot visualizations on validation.
                 If true, log every epoch. Defaults to 10. If int, will plot every plot_on_val epochs.
-            tiled_inference_parameters (TiledInferenceParameters | None, optional): Inference parameters
+            tiled_inference_parameters (dict | None, optional): Inference parameters
                 used to determine if inference is done on the whole image or through tiling.
             test_dataloaders_names (list[str] | None, optional): Names used to differentiate metrics when
                 multiple dataloaders are returned by test_dataloader in the datamodule. Defaults to None,
@@ -200,9 +200,9 @@ class PixelwiseRegressionTask(TerraTorchTask):
             lr_overrides (dict[str, float] | None, optional): Dictionary to override the default lr in specific
                 parameters. The key should be a substring of the parameter names (it will check the substring is
                 contained in the parameter name)and the value should be the new lr. Defaults to None.
-            tiled_inference_on_testing (bool): A boolean to the fine if tiled inference will be used when full inference 
-                fails during the test step. 
-            path_to_record_metrics (str): A path to save the file containing the metrics log. 
+            tiled_inference_on_testing (bool): A boolean to the fine if tiled inference will be used when full inference
+                fails during the test step.
+            path_to_record_metrics (str): A path to save the file containing the metrics log.
         """
 
         self.tiled_inference_parameters = tiled_inference_parameters
@@ -394,11 +394,10 @@ class PixelwiseRegressionTask(TerraTorchTask):
         rest = {k: batch[k] for k in other_keys}
 
         def model_forward(x, **kwargs):
-            return self(x).output
+            return self(x, **kwargs).output
 
         if self.tiled_inference_parameters:
-            # TODO: tiled inference does not work with additional input data (**rest)
-            y_hat: Tensor = tiled_inference(model_forward, x, 1, self.tiled_inference_parameters, **rest)
+            y_hat: Tensor = tiled_inference(model_forward, x, **self.tiled_inference_parameters, **rest)
         else:
             y_hat: Tensor = self(x, **rest).output
         return y_hat, file_names

--- a/terratorch/tasks/segmentation_tasks.py
+++ b/terratorch/tasks/segmentation_tasks.py
@@ -65,7 +65,7 @@ class SemanticSegmentationTask(TerraTorchTask):
         freeze_head: bool = False, 
         plot_on_val: bool | int = 10,
         class_names: list[str] | None = None,
-        tiled_inference_parameters: TiledInferenceParameters = None,
+        tiled_inference_parameters: dict = None,
         test_dataloaders_names: list[str] | None = None,
         lr_overrides: dict[str, float] | None = None,
         output_on_inference: str | list[str] = "prediction",
@@ -109,7 +109,7 @@ class SemanticSegmentationTask(TerraTorchTask):
             If true, log every epoch. Defaults to 10. If int, will plot every plot_on_val epochs.
             class_names (list[str] | None, optional): List of class names passed to metrics for better naming.
                 Defaults to numeric ordering.
-            tiled_inference_parameters (TiledInferenceParameters | None, optional): Inference parameters
+            tiled_inference_parameters (dict | None, optional): Inference parameters
                 used to determine if inference is done on the whole image or through tiling.
             test_dataloaders_names (list[str] | None, optional): Names used to differentiate metrics when
                 multiple dataloaders are returned by test_dataloader in the datamodule. Defaults to None,
@@ -395,8 +395,7 @@ class SemanticSegmentationTask(TerraTorchTask):
             y_hat: Tensor = tiled_inference(
                 model_forward,
                 x,
-                self.hparams["model_args"]["num_classes"],
-                self.tiled_inference_parameters,
+                **self.tiled_inference_parameters,
                 **rest,
             )
         else:

--- a/terratorch/tasks/tiled_inference.py
+++ b/terratorch/tasks/tiled_inference.py
@@ -178,7 +178,7 @@ def get_input_chips_wo_padding(
 def tiled_inference(
         model_forward: Callable,
         input_batch: torch.Tensor,
-        out_channels:  int = None,
+        out_channels:  int | None = None,
         inference_parameters: TiledInferenceParameters = None,
         h_crop: int = 224,
         w_crop: int = 224,
@@ -255,8 +255,8 @@ def tiled_inference(
             output = [output[i] for i in range(len(batch))]
             for batch_input, predicted in zip(batch, output, strict=True):
                 if preds is None:
-                    # Initialize preds based on first outputh
-                    out_channels = predicted.shape[0]
+                    # Initialize preds based on first output
+                    out_channels = 1 if len(predicted.shape) == 2 else predicted.shape[0]
                     preds = input_batch.new_zeros((input_batch_size, out_channels, h_img, w_img))
                 if batch_input.output_crop is not None:
                     predicted = predicted[..., batch_input.output_crop[0], batch_input.output_crop[1]]


### PR DESCRIPTION
- Added padding based on `delta` parameter (defaults to `reflect`).
- Switch from the `inference_parameters` param to actuall arguments. `inference_parameters` is still working and should be removed in version 1.3.
- Added params `crop` and `stride` which are applied to both dims, should make it easier for users. `h_...` and `w_...` are still possible. 
- Fixed some errors in the code.
- Add blend mask to smooth overkapps and avoild edges between tiles. The blending can be deactivated with `blend_overlaps=False`.

Example of a blend mask for a setting `h_crop=256, h_stride=180, w_crop=256, w_stride=180`:

![sample_blend_mask](https://github.com/user-attachments/assets/4011d36a-b3b0-4899-a91b-044e70fe15c9)

Blended summed weights over all tiles. Note that the edges are not scalled because the `preds` are mulitplied with the blend mask.
![new_blend_mask](https://github.com/user-attachments/assets/9ba7c5b6-bc04-4b91-ba52-f902c68bfbe7)



Counts over all tiles with `blend_overlaps=False` (old setting):
![old_blend_mask](https://github.com/user-attachments/assets/8b78e8bf-57e2-4e44-ac4a-2464af021a7f)

