### PR TITLE
fix: rename file to checkpoint.pt

### DIFF
--- a/examples/tutorials/PrithviEOv2/prithvi_v2_eo_300_tl_unet_burnscars_tensorrt.ipynb
+++ b/examples/tutorials/PrithviEOv2/prithvi_v2_eo_300_tl_unet_burnscars_tensorrt.ipynb
@@ -242,8 +242,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not os.path.isfile('hls_burn_scars.tar.gz'):\n",
-    "    gdown.download(\"https://drive.google.com/uc?id=1-I_DiiO2T1mjBTi3OAJaVeRWKHtAG63N\")"
+    "if not os.path.isfile('checkpoint.pt'):\n",
+    "    gdown.download(\n",
+    "        \"https://drive.google.com/uc?id=1-I_DiiO2T1mjBTi3OAJaVeRWKHtAG63N\",\n",
+    "        output=\"checkpoint.pt\",\n",
+    "        quiet=False\n",
+    "    )"
    ]
   },
   {


### PR DESCRIPTION
The file is actually a model checkpoint, not a dataset. I’ve renamed it to checkpoint.pt to align with the naming convention used in the notebook.