### PR TITLE
add missing import: from torchmetrics.wrappers import ClasswiseWrapper

### DIFF
--- a/terratorch/tasks/multilabel_classification_tasks.py
+++ b/terratorch/tasks/multilabel_classification_tasks.py
@@ -13,7 +13,7 @@ from torchmetrics.classification import (
     MultilabelRecall,
     MultilabelAUROC,
 )
-
+from torchmetrics.wrappers import ClasswiseWrapper
 from terratorch.models.model import ModelOutput
 from terratorch.tasks import ClassificationTask
 


### PR DESCRIPTION
it seems that the ClasswiseWrapper class has not been properly imported in `terratorch/tasks/multilabel_classification_tasks.py` so it raises this error message:
```shell
NameError: name 'ClasswiseWrapper' is not defined
```