### PR TITLE
Increasing timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    timeout-minutes: 40
     strategy:
       matrix:
         python-version: ["3.11", "3.12", "3.13"]


### PR DESCRIPTION
The tests for 3.13 are taking more than 35 minutes, so I increased the timeout. 