### PR TITLE
Missing dependencies for deploying documentation

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -18,6 +18,9 @@ jobs:
       name: github-pages
       url: ibm.github.io/terratorch/
     steps:
+      - name: Install dependencies
+        run: |
+          pip install mkdocs-material mike  mkdocstrings[python] mkdocs-git-revision-date-localized-plugin
       - name: Clone repo
         uses: actions/checkout@v4
       - name: deploy documentation


### PR DESCRIPTION
@blumenstiel I changed the permission for `update-docs`, so now it should be able to deploy to github.io. 
However, there is [another error](https://github.com/IBM/terratorch/actions/runs/16951759271/job/48045837028), since  dependencies as `mike`were not installed. This PR should solve it. 