### PR TITLE
Fix docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Install dependencies
         run: |
-          pip install mkdocs-material mike  mkdocstrings[python] mkdocs-git-revision-date-localized-plugin
+          pip install mkdocs-material mike mkdocstrings[python] mkdocs-git-revision-date-localized-plugin timm
       - name: Clone repo
         uses: actions/checkout@v4
       - name: deploy documentation


### PR DESCRIPTION
Install timm in docs workflow

Followup from https://github.com/IBM/terratorch/pull/794

Fixing error `ModuleNotFoundError: No module named 'timm'`, see https://github.com/IBM/terratorch/actions/runs/16960714093/job/48072625145#step:4:701