### PR TITLE
Making Galileo optional

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,9 @@ jobs:
           #python -m pip install --upgrade pip
           pip install pip==24.2
           pip --version
-          pip install -e .[wxc,galileo,test]
+          pip install -e .[wxc,test]
+          # Installing dependencies required to test Galileo (temporary)
+          pip install git+https://github.com/Joao-L-S-Almeida/terratorch-galileo.git
       - name: Clean pip cache
         run: pip cache purge
       - name: List pip dependencies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,10 +107,6 @@ peft = [
   "peft>=0.15.0"
 ]
 
-galileo = [
-  "galileo @ git+https://github.com/Joao-L-S-Almeida/terratorch-galileo.git"
-]
-
 [project.urls]
 Documentation = "https://ibm.github.io/terratorch/"
 Issues = "https://github.com/IBM/terratorch/issues"


### PR DESCRIPTION
As Galileo will be incorporated to TerraTorch, this operation will guarantee the current implementation is tested and avoid issues when installing via PyPI. 
This changes were took since we don't have a defined timeline for the inclusion of Galileo as part of TerraTorch and it can happen just after the release of 1.1 