### PR TITLE
Fix ReshapeTokensToImage

### DIFF
--- a/terratorch/models/encoder_decoder_factory.py
+++ b/terratorch/models/encoder_decoder_factory.py
@@ -12,7 +12,7 @@ from terratorch.models.model import (
     Model,
     ModelFactory,
 )
-from terratorch.models.necks import Neck, build_neck_list
+from terratorch.models.necks import Neck, build_neck_list, NeckSequential
 from terratorch.models.peft_utils import get_peft_backbone
 from terratorch.models.pixel_wise_model import PixelWiseModel
 from terratorch.models.scalar_output_model import ScalarOutputModel
@@ -247,7 +247,7 @@ def _build_appropriate_model(
     auxiliary_heads: list[AuxiliaryHeadWithDecoderWithoutInstantiatedHead] | None = None,
 ):
     if necks:
-        neck_module: nn.Module = nn.Sequential(*necks)
+        neck_module: nn.Module = NeckSequential(necks)
     else:
         neck_module = None
     if task in PIXEL_WISE_TASKS:

--- a/terratorch/models/object_detection_model_factory.py
+++ b/terratorch/models/object_detection_model_factory.py
@@ -7,7 +7,7 @@ from terratorch.models.model import (
     Model,
     ModelFactory,
 )
-from terratorch.models.necks import build_neck_list
+from terratorch.models.necks import build_neck_list, NeckSequential
 from terratorch.models.model import ModelOutput
 from terratorch.models.utils import extract_prefix_keys
 from terratorch.registry import MODEL_FACTORY_REGISTRY
@@ -93,7 +93,7 @@ class ObjectDetectionModelFactory(ModelFactory):
             necks = []
         neck_list, channel_list = build_neck_list(necks, out_channels)
 
-        neck_module = nn.Sequential(*neck_list)
+        neck_module = NeckSequential(neck_list)
 
         combined_backbone = BackboneWrapper(backbone, neck_module, channel_list)
         # pdb.set_trace()

--- a/terratorch/models/pixel_wise_model.py
+++ b/terratorch/models/pixel_wise_model.py
@@ -70,7 +70,16 @@ class PixelWiseModel(Model, SegmentationModel):
             aux_heads = {}
         self.aux_heads = nn.ModuleDict(aux_heads)
 
-        self.neck = neck
+        if neck is not None:
+            self.neck = neck
+        elif hasattr(self.encoder, "prepare_features_for_image_model"):
+            # only for backwards compatibility with pre-neck times.
+            def model_defined_neck(x, **kwargs):
+                return self.encoder.prepare_features_for_image_model(x)  # Drop kwargs
+            self.neck = model_defined_neck
+        else:
+            self.neck = nn.Identity()
+
         self.rescale = rescale
         self.patch_size = patch_size
         self.padding = padding
@@ -119,14 +128,7 @@ class PixelWiseModel(Model, SegmentationModel):
 
         features = self.encoder(x, **kwargs)
 
-        # only for backwards compatibility with pre-neck times.
-        if self.neck:
-            prepare = self.neck
-        else:
-            # for backwards compatibility, if this is defined in the encoder, use it
-            prepare = getattr(self.encoder, "prepare_features_for_image_model", lambda x: x)
-
-        features = prepare(features)
+        features = self.neck(features, image_size=input_size)
 
         decoder_output = self.decoder([f.clone() for f in features])
         mask = self.head(decoder_output)

--- a/terratorch/models/scalar_output_model.py
+++ b/terratorch/models/scalar_output_model.py
@@ -66,7 +66,16 @@ class ScalarOutputModel(Model, SegmentationModel):
             aux_heads = {}
         self.aux_heads = nn.ModuleDict(aux_heads)
 
-        self.neck = neck
+        if neck is not None:
+            self.neck = neck
+        elif hasattr(self.encoder, "prepare_features_for_image_model"):
+            # only for backwards compatibility with pre-neck times.
+            def model_defined_neck(x, **kwargs):
+                return self.encoder.prepare_features_for_image_model(x)  # Drop kwargs
+
+            self.neck = model_defined_neck
+        else:
+            self.neck = nn.Identity()
         self.patch_size = patch_size
         self.padding = padding
 
@@ -85,16 +94,18 @@ class ScalarOutputModel(Model, SegmentationModel):
         if isinstance(x, torch.Tensor) and self.patch_size:
             # Only works for single image modalities
             x = pad_images(x, self.patch_size, self.padding)
+            input_size = x.shape[-2:]
+        elif isinstance(x, dict):
+            # Multimodal input in passed as dict (Assuming first modality to be an image)
+            input_size = list(x.values())[0].shape[-2:]
+        elif hasattr(kwargs, 'image_size'):
+            input_size = kwargs['image_size']
+        else:
+            ValueError('Could not infer image shape.')
+
         features = self.encoder(x, **kwargs)
 
-        # only for backwards compatibility with pre-neck times.
-        if self.neck:
-            prepare = self.neck
-        else:
-            # for backwards compatibility, if this is defined in the encoder, use it
-            prepare = getattr(self.encoder, "prepare_features_for_image_model", lambda x: x)
-
-        features = prepare(features)
+        features = self.neck(features, input_size=input_size)
 
         decoder_output = self.decoder([f.clone() for f in features])
         mask = self.head(decoder_output)

--- a/terratorch/tasks/base_task.py
+++ b/terratorch/tasks/base_task.py
@@ -182,3 +182,10 @@ class TerraTorchTask(BaseTask):
             filename = os.path.join(self.path_to_record_metrics, "metrics.csv")
             metrics_record.to_csv(filename)
 
+    def load_state_dict(self, state_dict, strict=True):
+        # Update neck layer name for backwards compatibility
+        for key in list(state_dict.keys()):
+            if "neck" in key and "neck.layers" not in key:
+                state_dict[key.replace("neck", "neck.layers")] = state_dict.pop(key)
+
+        return super().load_state_dict(state_dict, strict=strict)


### PR DESCRIPTION
ReshapeTokensToImage did not infer the grid size correctly. Added the possibility to pass kwargs to a neck. Passing input_size to ReshapeTokensToImage to get patch_size and then the height.

Fall back to remove_cls_token=False, with first error.