### PR TITLE
Adding `dask`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,7 @@ dependencies = [
   "hdf5plugin",
   "h5netcdf",
   "pytest-sugar",
+  "dask",
 ]
 
 
@@ -90,8 +91,6 @@ test = [
   "pytest-coverage",
   "coverage-badge",
   "peft>=0.15.0",
-  "diffusers>=0.30.0",
-  "dask",
   "wandb",
 ]
 


### PR DESCRIPTION
It looks like `dask` must be mandatory to use the package. 
`diffusers` is already installed by default. 