### PR TITLE
Improve/data root handling

### DIFF
--- a/terratorch/datamodules/generic_multimodal_data_module.py
+++ b/terratorch/datamodules/generic_multimodal_data_module.py
@@ -380,25 +380,28 @@ class GenericMultiModalDataModule(NonGeoDataModule):
             raise ValueError(f"GenericMultiModalDataModule can only handle label_grep with suffixes "
                              f"(e.g. '*_mask.tif'). Intermediate wildcards do not work, found {label_grep}.")
         self.label_grep = label_grep
-        self.train_root = train_data_root
-        self.val_root = val_data_root
-        self.test_root = test_data_root
         self.train_label_data_root = train_label_data_root
         self.val_label_data_root = val_label_data_root
         self.test_label_data_root = test_label_data_root
-        self.predict_root = predict_data_root
 
         # Check paths and modalities
         for name, data_root in [("train", train_data_root), ("val", val_data_root), ("test", test_data_root),
                                 ("predict", predict_data_root)]:
             if data_root is None:
                 pass
-            elif allow_missing_modalities:
-                if not set(data_root.keys()) <= set(modalities):
-                    raise ValueError(f"Modalities {modalities} do not match {name}_data_root: {data_root}")
             else:
-                if not set(data_root.keys()) == set(modalities):
-                    raise ValueError(f"Paths in {name}_data_root do not match modalities {modalities}: {data_root}")
+                filtered = {m: data_root[m] for m in modalities if m in data_root} # Filter out modalities not used
+                if not allow_missing_modalities:
+                    if not set(filtered.keys()) == set(modalities):
+                        raise ValueError(f"Paths in {name}_data_root do not match modalities {modalities}: {data_root}")
+                if name == "train":
+                    self.train_root = filtered
+                elif name == "val":
+                    self.val_root = filtered
+                elif name == "test":
+                    self.test_root = filtered
+                elif name == "predict":
+                    self.predict_root = filtered
 
         self.train_split = train_split
         self.val_split = val_split

--- a/terratorch/datamodules/generic_multimodal_data_module.py
+++ b/terratorch/datamodules/generic_multimodal_data_module.py
@@ -388,20 +388,20 @@ class GenericMultiModalDataModule(NonGeoDataModule):
         for name, data_root in [("train", train_data_root), ("val", val_data_root), ("test", test_data_root),
                                 ("predict", predict_data_root)]:
             if data_root is None:
-                pass
+                filtered = None
             else:
                 filtered = {m: data_root[m] for m in modalities if m in data_root} # Filter out modalities not used
                 if not allow_missing_modalities:
                     if not set(filtered.keys()) == set(modalities):
                         raise ValueError(f"Paths in {name}_data_root do not match modalities {modalities}: {data_root}")
-                if name == "train":
-                    self.train_root = filtered
-                elif name == "val":
-                    self.val_root = filtered
-                elif name == "test":
-                    self.test_root = filtered
-                elif name == "predict":
-                    self.predict_root = filtered
+            if name == "train":
+                self.train_root = filtered
+            elif name == "val":
+                self.val_root = filtered
+            elif name == "test":
+                self.test_root = filtered
+            elif name == "predict":
+                self.predict_root = filtered
 
         self.train_split = train_split
         self.val_split = val_split


### PR DESCRIPTION
Suggestion to adapt data root handling so `data_roots` may contain more modalities than needed.

Previously, roots had to either match `modalities` exactly or be a subset (for allow_missing); now we filter roots based on `modalities`. This lets you keep all modality paths in a data config, and simply adapt the `modality` argument, without having to manually comment out root paths.

The allow_missing_modalities logic is unchanged. 
