### PR TITLE
Trying to enforce the latest version of torchgeo

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = [
   "segmentation-models-pytorch<=0.4",
   "jsonargparse",
   "pytest",
-  "torchgeo",
+  "torchgeo>=0.7.0",
   "einops",
   "timm>=1.0.15",
   "pycocotools",


### PR DESCRIPTION
When the version is enforced, the behaviors of `uv` and `pip` become more similar. 