### PR TITLE
change import to support new package name of tt-iterate

### DIFF
--- a/terratorch/__main__.py
+++ b/terratorch/__main__.py
@@ -10,7 +10,7 @@ from huggingface_hub import hf_hub_download
 from terratorch.cli_tools import build_lightning_cli
 
 try:
-    from benchmark.main import main as iterate_main
+    from terratorch_iterate.main import main as iterate_main
 
     TERRATORCH_ITERATE_INSTALLED = True
 


### PR DESCRIPTION
the goal of this PR is to allow users to execute the latest version of tt-iterate, which has a new package name - closes issue #917 