### PR TITLE
Special Exception to handle models missing from the registry

### DIFF
--- a/terratorch/registry/timm_registry.py
+++ b/terratorch/registry/timm_registry.py
@@ -5,7 +5,7 @@ import torch
 from torch import nn
 
 from terratorch.registry import BACKBONE_REGISTRY
-from terratorch.utils import remove_unexpected_prefix
+from terratorch.utils import InvalidModelError, remove_unexpected_prefix
 
 
 class TimmBackboneWrapper(nn.Module):
@@ -18,9 +18,11 @@ class TimmBackboneWrapper(nn.Module):
         self.forward = timm_module.forward
         if hasattr(timm_module, "freeze"):
             self.freeze = timm_module.freeze
+
     @property
     def out_channels(self):
         return self._out_channels
+
 
 class TimmRegistry(Set):
     """Registry wrapper for timm"""
@@ -44,7 +46,7 @@ class TimmRegistry(Set):
         except RuntimeError as e:
             if "Unknown model" in str(e):
                 msg = f"Unknown model {name}"
-                raise KeyError(msg) from e
+                raise InvalidModelError(msg, model_name=name) from e
             raise e
 
     def __iter__(self):
@@ -64,7 +66,6 @@ class TimmRegistry(Set):
 
     def __str__(self):
         return f"timm registry with {len(self)} registered backbones"
-
 
 
 TIMM_BACKBONE_REGISTRY = TimmRegistry()

--- a/terratorch/utils.py
+++ b/terratorch/utils.py
@@ -8,6 +8,15 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 
+# Special Exception to handle cases in which the model is missing from the
+# registries
+class InvalidModelError(Exception):
+    def __init__(self, message, model_name=None):
+        if not message:
+            message = f"InvalidModelError: The model {model_name} isn't in the register"
+        super().__init__(message)
+
+
 def compute_statistics(dataloader: DataLoader) -> dict[str, list[float]]:
     n_bands = dataloader.dataset[0]["image"].shape[0]
     n_data = torch.zeros([n_bands], dtype=torch.int64)


### PR DESCRIPTION
The exception `KeyError` is to generic to be suppressed. Sometimes the it is produced when the model is mising from the sources, and sometimes when there is a missing parameter in the configuration dictionaries. By creating a special exception we can provide more informatio for the user to understand why the instantiation is failing. 